### PR TITLE
typo in fibs

### DIFF
--- a/src/main/scala/fpinscala/answers/laziness.scala
+++ b/src/main/scala/fpinscala/answers/laziness.scala
@@ -29,7 +29,7 @@ object Stream {
     Stream.cons(i, from(i+1)) 
 
   def fibs: Stream[Int] = { 
-    def go(lag2: Int, lag1: Int): Stream[Int] = 
+    def go(lag1: Int, lag2: Int): Stream[Int] =
       Stream.cons(lag1, go(lag2, lag1+lag2))
     go(0, 1) 
   }


### PR DESCRIPTION
There was a typo in fibs.

diff --git a/src/main/scala/fpinscala/answers/laziness.scala b/src/main/scala/fpinscala/answers/laziness.scala
index 5082ed9..27df66e 100644
--- a/src/main/scala/fpinscala/answers/laziness.scala
+++ b/src/main/scala/fpinscala/answers/laziness.scala
@@ -29,7 +29,7 @@ object Stream {
     Stream.cons(i, from(i+1))

   def fibs: Stream[Int] = {
-    def go(lag2: Int, lag1: Int): Stream[Int] =
-    def go(lag1: Int, lag2: Int): Stream[Int] =
     Stream.cons(lag1, go(lag2, lag1+lag2))
   go(0, 1)
  }
