### PR TITLE
Correctly decrement the counter in the Stream.takeViaUnfold method.

### DIFF
--- a/answerkey/laziness/12.answer.scala
+++ b/answerkey/laziness/12.answer.scala
@@ -47,11 +47,10 @@ def zipWithAll[B,C](s2: Stream[B])(f: (Option[A],Option[B]) => C): Stream[C] = {
   val a = this map (Some(_)) append (constant(None)) 
   val b = s2 map (Some(_)) append (constant(None)) 
   unfold((a, b)) {
-    case (s1,s2) if s1.isEmpty && s2.isEmpty => None
     case (s1,s2) => {
       val (h1,t1) = s1.uncons.get 
       val (h2,t2) = s2.uncons.get
-      Some((f(h1,h2), (t1,t2)))
+      if(h1.isEmpty && h2.isEmpty) None else Some((f(h1,h2), (t1,t2)))
     }
   }
 }

--- a/answers/src/main/scala/fpinscala/laziness/Stream.scala
+++ b/answers/src/main/scala/fpinscala/laziness/Stream.scala
@@ -118,11 +118,10 @@ trait Stream[+A] {
     val a = this map (Some(_)) append (constant(None)) 
     val b = s2 map (Some(_)) append (constant(None)) 
     unfold((a, b)) {
-      case (s1,s2) if s1.isEmpty && s2.isEmpty => None
       case (s1,s2) => {
         val (h1,t1) = s1.uncons.get 
         val (h2,t2) = s2.uncons.get
-        Some((f(h1,h2), (t1,t2)))
+        if(h1.isEmpty && h2.isEmpty) None else Some((f(h1,h2), (t1,t2)))
       }
     }
   }


### PR DESCRIPTION
The counter passed to the unfold functions is now decremented at each
unfold step, preventing non terminating recursion.

The Stream.zipWithAll function is more in line with the book description, which states the zipped stream
should end when both original zipped streams have no more elements left.

Sorry for making a request on the main trunk, but it seems such a trivial error.
