### PR TITLE
Format string in GettingStarted.scala is missing matching param and causing runtime failure

### DIFF
--- a/exercises/src/main/scala/fpinscala/gettingstarted/GettingStarted.scala
+++ b/exercises/src/main/scala/fpinscala/gettingstarted/GettingStarted.scala
@@ -48,7 +48,7 @@ object MyModule {
   // accept a _function_ as a parameter
   def formatResult(name: String, n: Int, f: Int => Int) = { 
     val msg = "The %s of %d is %d." 
-    msg.format(n, f(n))
+    msg.format(name, n, f(n))
   }
 }
 


### PR DESCRIPTION
Looks like the missing param is `name`, Simple fix. I noticed this last night at Boston Scala.
**Before**

```
[info] Running fpinscala.gettingstarted.FormatAbsAndFactorial
[error] (run-main) java.util.MissingFormatArgumentException: Format specifier 'd'
java.util.MissingFormatArgumentException: Format specifier 'd'
    at java.util.Formatter.format(Formatter.java:2487)
    at java.util.Formatter.format(Formatter.java:2423)
    at java.lang.String.format(String.java:2797)
    at scala.collection.immutable.StringLike$class.format(StringLike.scala:266)
    at scala.collection.immutable.StringOps.format(StringOps.scala:31)
    at fpinscala.gettingstarted.MyModule$.formatResult(GettingStarted.scala:51)
```

**After**

```
[info] Running fpinscala.gettingstarted.FormatAbsAndFactorial
The absolute value of -42 is 42.
The factorial of 7 is 5040.
```
