### PR TITLE
Correction for answerkey/monoids/5.answer.scala

### DIFF
--- a/answerkey/monoids/5.answer.scala
+++ b/answerkey/monoids/5.answer.scala
@@ -1,4 +1,7 @@
-def trimMonoid(s: String): Monoid[String] = new Monoid[String] {
-  def op(a: String, b: String) = (a.trim + " " + b.trim).trim
-  val zero = ""
+def wordsMonoid: Monoid[String] = new Monoid[String]{
+	def op(s1: String, s2: String): String = 
+			if(s1 == zero) s2
+			else if(s2 == zero) s1
+			else (s1.trim + " " + s2.trim).trim
+	val zero: String = " "
 }


### PR DESCRIPTION
The original implementation does not satisfy the laws for zero:
op("", " a") = "a" != " a".

The proposed implementation uses " " for zero and performs explicit checks whether operands are zero.
