### PR TITLE
formatResult needs to pass name to format

### DIFF
--- a/exercises/src/main/scala/fpinscala/gettingstarted/GettingStarted.scala
+++ b/exercises/src/main/scala/fpinscala/gettingstarted/GettingStarted.scala
@@ -48,7 +48,7 @@ object MyModule {
   // accept a _function_ as a parameter
   def formatResult(name: String, n: Int, f: Int => Int) = { 
     val msg = "The %s of %d is %d." 
-    msg.format(n, f(n))
+    msg.format(name, n, f(n))
   }
 }
 


### PR DESCRIPTION
Without this patch the following exception occurs when trying to run FormatAbsAndFactorial:

Exception in thread "main" java.util.MissingFormatArgumentException: Format specifier 'd'
    at java.util.Formatter.format(Formatter.java:2432)
    at java.util.Formatter.format(Formatter.java:2367)
    at java.lang.String.format(String.java:2769)
    at scala.collection.immutable.StringLike$class.format(StringLike.scala:266)
    at scala.collection.immutable.StringOps.format(StringOps.scala:31)
    at fpinscala.gettingstarted.MyModule$.formatResult(GettingStarted.scala:58)
    at fpinscala.gettingstarted.AnonymousFunctions$.main(GettingStarted.scala:82)
    at fpinscala.gettingstarted.AnonymousFunctions.main(GettingStarted.scala)
    at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
    at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:39)
    at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:25)
    at java.lang.reflect.Method.invoke(Method.java:597)
    at com.intellij.rt.execution.application.AppMain.main(AppMain.java:120)
