### PR TITLE
Ch15 ex1: fix Process.|> implementation.

### DIFF
--- a/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
@@ -149,7 +149,7 @@ object SimpleStreamTransducers {
         if (emit isEmpty) tail |> Await(f, fb) 
         else f(emit.head) match {
           case Await(f2, fb2) => feed(emit.tail, tail, f2, fb2)
-          case p => Emit(emit, tail) |> p
+          case p => Emit(emit.tail, tail) |> p
         }
       p2 match {
         case Halt() => Halt()
@@ -157,7 +157,7 @@ object SimpleStreamTransducers {
         case Await(f,fb) => this match {
           case Emit(h,t) => feed(h, t, f, fb)
           case Halt() => Halt() |> fb
-          case Await(g,gb) => Await((i: I) => g(i) |> p2, gb |> fb)
+          case Await(g,gb) => Await((i: I) => g(i) |> p2, gb |> p2)
         }
       }
     }


### PR DESCRIPTION
I think there are two bugs in the implementation, here's my test case:

``` scala
def appendMinus1: Process[Int, Int] = Await(
  i => Emit(Seq(i), appendMinus1),
  Emit(Seq(-1), Halt()))

val p = appendMinus1 |> appendMinus1

assert (p(Stream(1,2,3)).toList == List(1,2,3,-1,-1))
```
