### PR TITLE
Don't spoil answers to exercise 4.1.

### DIFF
--- a/exercises/src/main/scala/fpinscala/errorhandling/Option.scala
+++ b/exercises/src/main/scala/fpinscala/errorhandling/Option.scala
@@ -1,47 +1,29 @@
 package fpinscala.errorhandling
 
 sealed trait Option[+A] {
-  def map[B](f: A => B): Option[B] = this match {
-    case None => None
-    case Some(a) => Some(f(a))
-  }
+  def map[B](f: A => B): Option[B] = ???
   
-  def getOrElse[B>:A](default: => B): B = this match {
-    case None => default
-    case Some(a) => a
-  }
+  def getOrElse[B>:A](default: => B): B = ???
   
-  def flatMap[B](f: A => Option[B]): Option[B] = 
-    map(f) getOrElse None
+  def flatMap[B](f: A => Option[B]): Option[B] = ???
   
   /*
   Of course, we can also implement `flatMap` with explicit pattern matching.
   */
-  def flatMap_1[B](f: A => Option[B]): Option[B] = this match {
-    case None => None
-    case Some(a) => f(a)
-  }
+  def flatMap_1[B](f: A => Option[B]): Option[B] = ???
   
-  def orElse[B>:A](ob: => Option[B]): Option[B] = 
-    this map (Some(_)) getOrElse ob
+  def orElse[B>:A](ob: => Option[B]): Option[B] = ???
   
   /*
   Again, we can implement this with explicit pattern matching. 
   */
-  def orElse_1[B>:A](ob: => Option[B]): Option[B] = this match {
-    case None => ob 
-    case _ => this
-  }
+  def orElse_1[B>:A](ob: => Option[B]): Option[B] = ???
   
-  def filter(f: A => Boolean): Option[A] = this match {
-    case Some(a) if f(a) => this
-    case _ => None
-  }
+  def filter(f: A => Boolean): Option[A] = ???
   /*
   This can also be defined in terms of `flatMap`.
   */
-  def filter_1(f: A => Boolean): Option[A] =
-    flatMap(a => if (f(a)) Some(a) else None)
+  def filter_1(f: A => Boolean): Option[A] = ???
 }
 case class Some[+A](get: A) extends Option[A]
 case object None extends Option[Nothing]


### PR DESCRIPTION
Answers to v10 exercise 4.1 are in the `exercises` sources; this replaces them with `???`, in preparation for the upcoming Boston session.
