### PR TITLE
Warn Java 6 users on sbt startup that compiling answers will fail.

### DIFF
--- a/project/Build.scala
+++ b/project/Build.scala
@@ -11,7 +11,9 @@ object FPInScalaBuild extends Build {
   lazy val root =
     Project(id = "fpinscala",
             base = file("."),
-            settings = opts) aggregate (chapterCode, exercises, answers)
+            settings = opts ++ Seq(
+              onLoadMessage ~= (_ + nio2check())
+            )) aggregate (chapterCode, exercises, answers)
   lazy val chapterCode =
     Project(id = "chapter-code",
             base = file("chaptercode"),
@@ -24,5 +26,16 @@ object FPInScalaBuild extends Build {
     Project(id = "answers",
             base = file("answers"),
             settings = opts)
+
+  def nio2check(): String = {
+    val cls = "java.nio.channels.AsynchronousFileChannel"
+    try {Class.forName(cls); ""}
+    catch {case _: ClassNotFoundException =>
+      ("\nWARNING: JSR-203 \"NIO.2\" (" + cls + ") not found.\n" +
+       "You are probably running Java < 1.7; answers will not compile.\n" +
+       "You seem to be running " + System.getProperty("java.version") + ".\n" +
+       "Try `project exercises' before compile, or upgrading your JDK.")
+    }
+  }
 }
 


### PR DESCRIPTION
Compiling in Java 6, you get this error:

```
[error] …/fpinscala/answers/src/main/scala/fpinscala/iomonad/Future.scala:122: not found: type AsynchronousFileChannel
[error]   def read(file: AsynchronousFileChannel,
[error]                  ^
[error] one error found
[error] (answers/compile:compile) Compilation failed
```

This adds the following message on sbt startup.

```
[info] Set current project to fpinscala (in build file:…/fpinscala/)
[info] WARNING: JSR-203 "NIO.2" (java.nio.channels.AsynchronousFileChannel) not found.
[info] You are probably running Java < 1.7; answers will not compile.
[info] You seem to be running 1.6.0_27.
[info] Try `project exercises' before compile, or upgrading your JDK.
> █
```

Tested in Java (6, 7) × sbt (0.12.4, 0.13.0).
