### PR TITLE
Fix ./sbt not being runnable

### DIFF
--- a/sbt
+++ b/sbt
@@ -1,1 +1,2 @@
+#!/bin/bash
 java -Xmx1024M -XX:PermSize=300m -jar `dirname $0`/sbt-launch.jar "$@"


### PR DESCRIPTION
On my OS X I can't run ./sbt as described in the readme:

```
> ./sbt
Failed to execute process './sbt'. Reason:
exec: Exec format error
The file './sbt' is marked as an executable but could not be run by the operating system.
```

Prepending #!/bin/bash fixes it.
