### PR TITLE
another version of zipAll/zipWithAll which doesn't make finite streams infinite

### DIFF
--- a/answerkey/laziness/13.answer.scala
+++ b/answerkey/laziness/13.answer.scala
@@ -31,17 +31,10 @@ def zip[B](s2: Stream[B]): Stream[(A,B)] =
 def zipAll[B](s2: Stream[B]): Stream[(Option[A],Option[B])] = 
   zipWithAll(s2)((_,_))
 
-/* 
-There are a number of edge cases with this function. We can deal with some of these edge cases by treating each stream as an infinite series of `Option` values, which become `None` when the stream is exhausted. 
-*/
-def zipWithAll[B,C](s2: Stream[B])(f: (Option[A],Option[B]) => C): Stream[C] = {
-  val a = this map (Some(_)) append (constant(None)) 
-  val b = s2 map (Some(_)) append (constant(None)) 
-  unfold((a, b)) {
+def zipWithAll[B, C](s2: Stream[B])(f: (Option[A], Option[B]) => C): Stream[C] =
+  Stream.unfold((this, s2)) {
     case (Empty, Empty) => None
-    case (s1, s2) => for {
-      h1 <- s1.headOption
-      h2 <- s2.headOption
-    } yield (f(h1,h2), (s1 drop 1, s2 drop 1))
+    case (Cons(h, t), Empty) => Some(f(Some(h()), Option.empty[B]) -> (t(), empty[B]))
+    case (Empty, Cons(h, t)) => Some(f(Option.empty[A], Some(h())) -> (empty[A] -> t()))
+    case (Cons(h1, t1), Cons(h2, t2)) => Some(f(Some(h1()), Some(h2())) -> (t1() -> t2()))
   }
-}

--- a/answers/src/main/scala/fpinscala/laziness/Stream.scala
+++ b/answers/src/main/scala/fpinscala/laziness/Stream.scala
@@ -148,20 +148,13 @@ trait Stream[+A] {
   def zipAll[B](s2: Stream[B]): Stream[(Option[A],Option[B])] = 
     zipWithAll(s2)((_,_))
   
-  /* 
-  There are a number of edge cases with this function. We can deal with some of these edge cases by treating each stream as an infinite series of `Option` values, which become `None` when the stream is exhausted. 
-  */
-  def zipWithAll[B,C](s2: Stream[B])(f: (Option[A],Option[B]) => C): Stream[C] = {
-    val a = this map (Some(_)) append (constant(None)) 
-    val b = s2 map (Some(_)) append (constant(None)) 
-    unfold((a, b)) {
+  def zipWithAll[B, C](s2: Stream[B])(f: (Option[A], Option[B]) => C): Stream[C] =
+    Stream.unfold((this, s2)) {
       case (Empty, Empty) => None
-      case (s1, s2) => for {
-        h1 <- s1.headOption
-        h2 <- s2.headOption
-      } yield (f(h1,h2), (s1 drop 1, s2 drop 1))
+      case (Cons(h, t), Empty) => Some(f(Some(h()), Option.empty[B]) -> (t(), empty[B]))
+      case (Empty, Cons(h, t)) => Some(f(Option.empty[A], Some(h())) -> (empty[A] -> t()))
+      case (Cons(h1, t1), Cons(h2, t2)) => Some(f(Some(h1()), Some(h2())) -> (t1() -> t2()))
     }
-  }
 
   /* 
   `s startsWith s2` when corresponding elements of `s` and `s2` are all equal, until the point that `s2` is exhausted. If `s` is exhausted first, or we find an element that doesn't match, we terminate early. Using non-strictness, we can compose these three separate logical steps--the zipping, the termination when the second stream is exhausted, and the termination if a nonmatching element is found or the first stream is exhausted.


### PR DESCRIPTION
for current implementation `Stream(1).zipAll(Stream(2)).toList` never terminates
and `Stream(1).zipAll(Stream(2)).take(2).toList` returns `List((Some(1), Some(2)),(None, None))`
the implementation in this PR makes it work as you will expect, given the definition of `zipAll`:
`The zipAll function should continue the traversal as long as either stream has more elements`
