### PR TITLE
Omit an optional type variable of the Stream.filter method.

### DIFF
--- a/answers/src/main/scala/fpinscala/laziness/Stream.scala
+++ b/answers/src/main/scala/fpinscala/laziness/Stream.scala
@@ -105,7 +105,7 @@ trait Stream[+A] {
   def map[B](f: A => B): Stream[B] =
     foldRight(empty[B])((h,t) => cons(f(h), t)) 
   
-  def filter[B](f: A => Boolean): Stream[A] =
+  def filter(f: A => Boolean): Stream[A] =
     foldRight(empty[A])((h,t) => 
       if (f(h)) cons(h, t)
       else t) 


### PR DESCRIPTION
The type variable [B] of the fpinscala.lazyness.Stream.filter method
can be omitted.
