### PR TITLE
Copied parMap from answers section

### DIFF
--- a/exercises/src/main/scala/fpinscala/parallelism/Nonblocking.scala
+++ b/exercises/src/main/scala/fpinscala/parallelism/Nonblocking.scala
@@ -104,6 +104,12 @@ object Nonblocking {
 
     def sequence[A](as: List[Par[A]]): Par[List[A]] =
       map(sequenceBalanced(as.toIndexedSeq))(_.toList)
+    
+    def parMap[A,B](as: List[A])(f: A => B): Par[List[B]] =
+      sequence(as.map(asyncF(f)))
+
+    def parMap[A,B](as: IndexedSeq[A])(f: A => B): Par[IndexedSeq[B]] =
+      sequenceBalanced(as.map(asyncF(f)))
 
     // exercise answers
 


### PR DESCRIPTION
Otherwise the solution for parFoldMap in Monoid.scala won't compile

  def parFoldMap[A,B](v: IndexedSeq[A], m: Monoid[B])(f: A => B): Par[B] =
    Par.parMap(v)(f).flatMap { bs =>
      foldMapV(bs, par(m))(b => Par.lazyUnit(b))
    }
