### PR TITLE
Actor.scala does not compile in Scala 2.11

### DIFF
--- a/answers/src/main/scala/fpinscala/parallelism/Actor.scala
+++ b/answers/src/main/scala/fpinscala/parallelism/Actor.scala
@@ -36,7 +36,7 @@ import annotation.tailrec
  * @param strategy Execution strategy, for example, a strategy that is backed by an `ExecutorService`
  * @tparam A       The type of messages accepted by this actor.
  */
-final case class Actor[A](strategy: Strategy)(handler: A => Unit, onError: Throwable => Unit = throw(_)) {
+final case class Actor[A](strategy: Strategy)(handler: A => Unit, onError: Throwable => Unit) {
   self =>
 
   private val tail = new AtomicReference(new Node[A]())


### PR DESCRIPTION
Two methods apply with default arguments (the first from case class Actor and the second from object Apply) makes the code not compile in Scala 2.11. The easiest solution is to remove the default argument from case class.
