### PR TITLE
fpinscala-parallelism: Explains that the example map2 is semantically incorrect

### DIFF
--- a/exercises/src/main/scala/fpinscala/parallelism/Par.scala
+++ b/exercises/src/main/scala/fpinscala/parallelism/Par.scala
@@ -20,7 +20,7 @@ object Par {
     (es: ExecutorService) => {
       val af = a(es) 
       val bf = b(es)
-      UnitFuture(f(af.get, bf.get)) // This implementation of `map2` does _not_ respect timeouts. It simply passes the `ExecutorService` on to both `Par` values, waits for the results of the Futures `af` and `bf`, applies `f` to them, and wraps them in a `UnitFuture`. In order to respect timeouts, we'd need a new `Future` implementation that records the amount of time spent evaluating `af`, then subtracts that time from the available time allocated for evaluating `bf`.
+      UnitFuture(f(af.get, bf.get)) // This implementation of `map2` does _not_ respect timeouts, and eagerly waits for the returned futures. This means that even if you have passed in "forked" arguments, using this map2 on them will make them wait. It simply passes the `ExecutorService` on to both `Par` values, waits for the results of the Futures `af` and `bf`, applies `f` to them, and wraps them in a `UnitFuture`. In order to respect timeouts, we'd need a new `Future` implementation that records the amount of time spent evaluating `af`, then subtracts that time from the available time allocated for evaluating `bf`.
     }
   
   def fork[A](a: => Par[A]): Par[A] = // This is the simplest and most natural implementation of `fork`, but there are some problems with it--for one, the outer `Callable` will block waiting for the "inner" task to complete. Since this blocking occupies a thread in our thread pool, or whatever resource backs the `ExecutorService`, this implies that we're losing out on some potential parallelism. Essentially, we're using two threads when one should suffice. This is a symptom of a more serious problem with the implementation, and we will discuss this later in the chapter.


### PR DESCRIPTION
# Problem

The function returned by the example map2 waits for the underlying Futures to be finished before returning.  This means that

``` scala
exampleMap2(fork(par1), fork(par2), fn)
```

Will block and wait for fork to be finished for both of them.
# Solution

Clarify the comment.  Providing a correct implementation is tantamount to solving the exercise, which would be a waste.
# Extra

Fixed a memory visibility bug.
