### PR TITLE
Fix link to Travis build in the README file

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![Build status](https://travis-ci.org/fpinscala/fpinscala.svg?branch=master)
+[![Build status](https://travis-ci.org/fpinscala/fpinscala.svg?branch=master)](https://travis-ci.org/fpinscala/fpinscala)
 
 This repository contains exercises, hints, and answers for the book [Functional Programming in Scala](http://manning.com/bjarnason/). Along with the book itself, it's the closest you'll get to having your own private functional programming tutor without actually having one.
 


### PR DESCRIPTION
Clicking on the Travis badge currently directs to the image itself. This fixes that behavior by directing to the project on Travis.