### PR TITLE
[Exercise 4.5] Add sequenceViaTraverse

### DIFF
--- a/answerkey/errorhandling/05.answer.scala
+++ b/answerkey/errorhandling/05.answer.scala
@@ -6,3 +6,6 @@ def traverse[A, B](a: List[A])(f: A => Option[B]): Option[List[B]] =
 
 def traverse_1[A, B](a: List[A])(f: A => Option[B]): Option[List[B]] =
   a.foldRight[Option[List[B]]](Some(Nil))((h,t) => map2(f(h),t)(_ :: _))
+
+def sequenceViaTraverse[A](a: List[Option[A]]): Option[List[A]] =
+  traverse(a)(x => x)

--- a/answers/src/main/scala/fpinscala/errorhandling/Option.scala
+++ b/answers/src/main/scala/fpinscala/errorhandling/Option.scala
@@ -101,4 +101,7 @@ object Option {
 
   def traverse_1[A, B](a: List[A])(f: A => Option[B]): Option[List[B]] =
     a.foldRight[Option[List[B]]](Some(Nil))((h,t) => map2(f(h),t)(_ :: _))
+
+  def sequenceViaTraverse[A](a: List[Option[A]]): Option[List[A]] =
+    traverse(a)(x => x)
 }


### PR DESCRIPTION
Exercise 4.5 says:

> In fact, implement sequence in terms of traverse.

The hint in the repo also says:

> Implementing `sequence` using `traverse` may be more trivial than you think.

This is quite a teaser! The answer is simple indeed but one can try more complicated solutions without trying out the obvious, so I think it would be nice to add the solution in the answers.
Also, I was trying to find a nicer way than `(x => x)` but couldn't find anything, so correct me if I am wrong.

In addition, my text editor removed the trailing whitespaces of the 2 files. I think it's an improvement overall, but I split the commit in 2 in case you want me to get rid of it.
