### PR TITLE
Fix exercise 2.2 answer

### DIFF
--- a/answerkey/gettingstarted/02.answer.scala
+++ b/answerkey/gettingstarted/02.answer.scala
@@ -1,9 +1,9 @@
 def isSorted[A](as: Array[A], gt: (A,A) => Boolean): Boolean = {
   @annotation.tailrec
-  def go(i: Int, prev: A): Boolean = 
-    if (i == as.length) true
-    else if (gt(as(i), prev)) go(i + 1, as(i))
-    else false
-  if (as.length == 0) true
-  else go(1, as(0))
+  def go(n: Int): Boolean =
+    if (n >= as.length-1) true
+    else if (gt(as(n), as(n+1))) false
+    else go(n+1)
+
+  go(0)
 }

--- a/answerkey/gettingstarted/02.hint.txt
+++ b/answerkey/gettingstarted/02.hint.txt
@@ -1,1 +1,2 @@
-You know the array is not sorted as soon as you encounter two adjacent elements for which `gt` returns false.
+You know the array is not sorted as soon as you encounter two adjacent elements for which `gt(first, second)`
+returns true (note that equal adjacent elements are in order).

--- a/answers/src/main/scala/fpinscala/gettingstarted/GettingStarted.scala
+++ b/answers/src/main/scala/fpinscala/gettingstarted/GettingStarted.scala
@@ -136,12 +136,12 @@ object PolymorphicFunctions {
   // an `Array[A]` is sorted
   def isSorted[A](as: Array[A], gt: (A,A) => Boolean): Boolean = {
     @annotation.tailrec
-    def go(i: Int, prev: A): Boolean =
-      if (i == as.length) true
-      else if (gt(as(i), prev)) go(i + 1, as(i))
-      else false
-    if (as.length == 0) true
-    else go(1, as(0))
+    def go(n: Int): Boolean =
+      if (n >= as.length-1) true
+      else if (gt(as(n), as(n+1))) false
+      else go(n+1)
+
+    go(0)
   }
 
   // Polymorphic functions are often so constrained by their type


### PR DESCRIPTION
The previous code failed on consecutive equal array members, e.g. Array(1,1,2,3) was deemed unsorted. Also simplifies the answer slightly by getting rid of the prev argument in the go method and by removing the if/else from isSorted body.