### PR TITLE
fix Nonblocking choice typo

### DIFF
--- a/exercises/src/main/scala/fpinscala/parallelism/Nonblocking.scala
+++ b/exercises/src/main/scala/fpinscala/parallelism/Nonblocking.scala
@@ -126,7 +126,7 @@ object Nonblocking {
         def apply(cb: A => Unit): Unit =
           p(es) { b =>
             if (b) eval(es) { t(es)(cb) }
-            else eval(es) { t(es)(cb) }
+            else eval(es) { f(es)(cb) }
           }
       }
 


### PR DESCRIPTION
(Chapter 7) Choice should choose between f and t based on the result of p, not just use t in both cases. 1-character typo bugfix