### PR TITLE
Fixes order of second argument list in choice

### DIFF
--- a/exercises/src/main/scala/fpinscala/parallelism/Nonblocking.scala
+++ b/exercises/src/main/scala/fpinscala/parallelism/Nonblocking.scala
@@ -121,7 +121,7 @@ object Nonblocking {
      * through the implementation. What is the type of `p(es)`? What
      * about `t(es)`? What about `t(es)(cb)`?
      */
-    def choice[A](p: Par[Boolean])(f: Par[A], t: Par[A]): Par[A] =
+    def choice[A](p: Par[Boolean])(t: Par[A], f: Par[A]): Par[A] =
       es => new Future[A] {
         def apply(cb: A => Unit): Unit =
           p(es) { b =>


### PR DESCRIPTION
Switched order of `t` and `f` to match same method in Par.scala and
answers/….