### PR TITLE
Correction of substring/subsequence when passing an empty list

### DIFF
--- a/answerkey/datastructures/24.answer.scala
+++ b/answerkey/datastructures/24.answer.scala
@@ -16,8 +16,10 @@ def startsWith[A](l: List[A], prefix: List[A]): Boolean = (l,prefix) match {
   case _ => false
 }
 @annotation.tailrec
-def hasSubsequence[A](sup: List[A], sub: List[A]): Boolean = sup match {
-  case Nil => false
-  case _ if startsWith(sup, sub) => true
-  case Cons(h,t) => hasSubsequence(t, sub)
+def hasSubsequence[A](l: List[A], sub: List[A]): Boolean = (l, sub) match {
+  case (Nil, Nil) => true
+  case (Nil, _) => false
+  case (_, Nil) => false
+  case (_, _) if startsWith(l, sub) => true
+  case (Cons(_,t), _) => hasSubsequence(t, sub)
 }

--- a/answerkey/laziness/14.answer.scala
+++ b/answerkey/laziness/14.answer.scala
@@ -1,7 +1,11 @@
 /* 
 `s startsWith s2` when corresponding elements of `s` and `s2` are all equal, until the point that `s2` is exhausted. If `s` is exhausted first, or we find an element that doesn't match, we terminate early. Using non-strictness, we can compose these three separate logical steps--the zipping, the termination when the second stream is exhausted, and the termination if a nonmatching element is found or the first stream is exhausted.
 */
-def startsWith[A](s: Stream[A]): Boolean = 
-  zipAll(s).takeWhile(!_._2.isEmpty) forAll {
+def startsWith[A](s: Stream[A]): Boolean = (this, s) match {
+  case (Empty, Empty) => true
+  case (Empty, _) => false
+  case (_, Empty) => false
+  case _ => zipAll(s).takeWhile(!_._2.isEmpty) forAll {
     case (h,h2) => h == h2
   }
+}

--- a/answers/src/main/scala/fpinscala/datastructures/List.scala
+++ b/answers/src/main/scala/fpinscala/datastructures/List.scala
@@ -264,9 +264,11 @@ object List { // `List` companion object. Contains functions for creating and wo
     case _ => false
   }
   @annotation.tailrec
-  def hasSubsequence[A](sup: List[A], sub: List[A]): Boolean = sup match {
-    case Nil => false
-    case _ if startsWith(sup, sub) => true
-    case Cons(h,t) => hasSubsequence(t, sub)
+  def hasSubsequence[A](l: List[A], sub: List[A]): Boolean = (l, sub) match {
+    case (Nil, Nil) => true
+    case (Nil, _) => false
+    case (_, Nil) => false
+    case (_, _) if startsWith(l, sub) => true
+    case (Cons(_,t), _) => hasSubsequence(t, sub)
   }
 }

--- a/answers/src/main/scala/fpinscala/laziness/Stream.scala
+++ b/answers/src/main/scala/fpinscala/laziness/Stream.scala
@@ -155,10 +155,14 @@ trait Stream[+A] {
   /*
   `s startsWith s2` when corresponding elements of `s` and `s2` are all equal, until the point that `s2` is exhausted. If `s` is exhausted first, or we find an element that doesn't match, we terminate early. Using non-strictness, we can compose these three separate logical steps--the zipping, the termination when the second stream is exhausted, and the termination if a nonmatching element is found or the first stream is exhausted.
   */
-  def startsWith[A](s: Stream[A]): Boolean =
-    zipAll(s).takeWhile(!_._2.isEmpty) forAll {
+  def startsWith[A](s: Stream[A]): Boolean = (this, s) match {
+    case (Empty, Empty) => true
+    case (Empty, _) => false
+    case (_, Empty) => false
+    case _ => zipAll(s).takeWhile(!_._2.isEmpty) forAll {
       case (h,h2) => h == h2
     }
+  }
 
   /*
   The last element of `tails` is always the empty `Stream`, so we handle this as a special case, by appending it to the output.


### PR DESCRIPTION
I might be exaggerating, but considering the previous solution where an Empty List or Stream is considered a substring/subsequence of a non-empty one - is dangerous if leaked, for example, into production code.

For instance, imagine a case where subsequence/substring/startsWith checks if a user has completed certain pre-requisites. It will be erroneous to allow a user access, when the user has no pre-rerequisites completed (empty List or Stream).

Again, this might be an exaggeration, but only done in the context of strict correctness.