### PR TITLE
Suggestion to move answers files into their own package

### DIFF
--- a/answers/src/main/scala/fpinscala/applicative/Applicative.scala
+++ b/answers/src/main/scala/fpinscala/applicative/Applicative.scala
@@ -1,10 +1,9 @@
-package fpinscala
-package applicative
+package fpinscala.answers.applicative
 
-import monads.Functor
-import state._
-import State._
-import monoids._
+import fpinscala.answers.monads.Functor
+import fpinscala.answers.state._
+import fpinscala.answers.state.State._
+import fpinscala.answers.monoids._
 
 trait Applicative[F[_]] extends Functor[F] {
   // `map2` is implemented by first currying `f` so we get a function

--- a/answers/src/main/scala/fpinscala/datastructures/List.scala
+++ b/answers/src/main/scala/fpinscala/datastructures/List.scala
@@ -1,4 +1,4 @@
-package fpinscala.datastructures
+package fpinscala.answers.datastructures
 
 sealed trait List[+A] // `List` data type, parameterized on a type, `A`
 case object Nil extends List[Nothing] // A `List` data constructor representing the empty list

--- a/answers/src/main/scala/fpinscala/datastructures/Tree.scala
+++ b/answers/src/main/scala/fpinscala/datastructures/Tree.scala
@@ -1,4 +1,4 @@
-package fpinscala.datastructures
+package fpinscala.answers.datastructures
 
 sealed trait Tree[+A]
 case class Leaf[A](value: A) extends Tree[A]

--- a/answers/src/main/scala/fpinscala/errorhandling/Either.scala
+++ b/answers/src/main/scala/fpinscala/errorhandling/Either.scala
@@ -1,4 +1,4 @@
-package fpinscala.errorhandling
+package fpinscala.answers.errorhandling
 
 
 //hide std library `Option` and `Either`, since we are writing our own in this chapter

--- a/answers/src/main/scala/fpinscala/errorhandling/Option.scala
+++ b/answers/src/main/scala/fpinscala/errorhandling/Option.scala
@@ -1,4 +1,4 @@
-package fpinscala.errorhandling
+package fpinscala.answers.errorhandling
 
 //hide std library `Option` and `Either`, since we are writing our own in this chapter
 import scala.{Option => _, Either => _, _}

--- a/answers/src/main/scala/fpinscala/gettingstarted/GettingStarted.scala
+++ b/answers/src/main/scala/fpinscala/gettingstarted/GettingStarted.scala
@@ -1,4 +1,4 @@
-package fpinscala.gettingstarted
+package fpinscala.answers.gettingstarted
 
 // A comment!
 /* Another comment */

--- a/answers/src/main/scala/fpinscala/iomonad/BindTest.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/BindTest.scala
@@ -1,4 +1,4 @@
-package fpinscala.iomonad
+package fpinscala.answers.iomonad
 
 object BindTest extends App {
 
@@ -22,7 +22,7 @@ object BindTest extends App {
     }}
   }
 
-  import fpinscala.parallelism.Nonblocking._
+  import fpinscala.answers.parallelism.Nonblocking._
 
   object ParMonad extends Monad[Par] {
     def unit[A](a: => A) = Par.unit(a)

--- a/answers/src/main/scala/fpinscala/iomonad/IO.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/IO.scala
@@ -1,4 +1,4 @@
-package fpinscala.iomonad
+package fpinscala.answers.iomonad
 
 object IO0 {
                             /*
@@ -240,7 +240,7 @@ object IO2b {
 
 object IO2c {
 
-  import fpinscala.parallelism.Nonblocking._
+  import fpinscala.answers.parallelism.Nonblocking._
 
   /*
    * We've solved our first problem of ensuring stack safety, but we're still
@@ -346,7 +346,7 @@ object IO3 {
   only console I/O effects.
   */
 
-  import fpinscala.parallelism.Nonblocking.Par
+  import fpinscala.answers.parallelism.Nonblocking.Par
 
   sealed trait Console[A] {
     def toPar: Par[A]

--- a/answers/src/main/scala/fpinscala/iomonad/Monad.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/Monad.scala
@@ -1,5 +1,5 @@
 package fpinscala.answers.iomonad
-import scala.language.implicitConversions
+
 import language.higherKinds // Disable warnings for type constructor polymorphism
 
 trait Functor[F[_]] {

--- a/answers/src/main/scala/fpinscala/iomonad/Monad.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/Monad.scala
@@ -1,5 +1,5 @@
-package fpinscala.iomonad
-
+package fpinscala.answers.iomonad
+import scala.language.implicitConversions
 import language.higherKinds // Disable warnings for type constructor polymorphism
 
 trait Functor[F[_]] {

--- a/answers/src/main/scala/fpinscala/iomonad/Task.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/Task.scala
@@ -1,6 +1,6 @@
-package fpinscala.iomonad
+package fpinscala.answers.iomonad
 
-import fpinscala.parallelism.Nonblocking._
+import fpinscala.answers.parallelism.Nonblocking._
 import java.util.concurrent.ExecutorService
 
 /*

--- a/answers/src/main/scala/fpinscala/iomonad/Throw.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/Throw.scala
@@ -1,4 +1,4 @@
-package fpinscala.iomonad
+package fpinscala.answers.iomonad
 
 /**
  * A version of `TailRec` implemented using exceptions.

--- a/answers/src/main/scala/fpinscala/iomonad/package.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/package.scala
@@ -1,7 +1,10 @@
-package fpinscala
+package fpinscala.answers
+import scala.language.implicitConversions
+import scala.language.postfixOps
+import scala.language.higherKinds
 
 package object iomonad {
-  import fpinscala.parallelism.Nonblocking._
+  import fpinscala.answers.parallelism.Nonblocking._
 
   type IO[A] = IO3.IO[A]
   def IO[A](a: => A): IO[A] = IO3.IO[A](a)

--- a/answers/src/main/scala/fpinscala/iomonad/package.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/package.scala
@@ -1,7 +1,4 @@
 package fpinscala.answers
-import scala.language.implicitConversions
-import scala.language.postfixOps
-import scala.language.higherKinds
 
 package object iomonad {
   import fpinscala.answers.parallelism.Nonblocking._

--- a/answers/src/main/scala/fpinscala/laziness/Stream.scala
+++ b/answers/src/main/scala/fpinscala/laziness/Stream.scala
@@ -1,4 +1,4 @@
-package fpinscala.laziness
+package fpinscala.answers.laziness
 
 import Stream._
 trait Stream[+A] {

--- a/answers/src/main/scala/fpinscala/localeffects/LocalEffects.scala
+++ b/answers/src/main/scala/fpinscala/localeffects/LocalEffects.scala
@@ -1,6 +1,6 @@
-package fpinscala.localeffects
+package fpinscala.answers.localeffects
 
-import fpinscala.monads._
+import fpinscala.answers.monads._
 
 object Mutable {
   def quicksort(xs: List[Int]): List[Int] = if (xs.isEmpty) xs else {

--- a/answers/src/main/scala/fpinscala/monads/Monad.scala
+++ b/answers/src/main/scala/fpinscala/monads/Monad.scala
@@ -1,11 +1,12 @@
-package fpinscala
-package monads
+package fpinscala.answers.monads
 
-import parsing._
-import testing._
-import parallelism._
-import state._
-import parallelism.Par._
+import scala.language.higherKinds
+
+import fpinscala.answers.parsing._
+import fpinscala.answers.testing._
+import fpinscala.answers.parallelism._
+import fpinscala.answers.state._
+import fpinscala.answers.parallelism.Par._
 
 trait Functor[F[_]] {
   def map[A,B](fa: F[A])(f: A => B): F[B]

--- a/answers/src/main/scala/fpinscala/monads/Monad.scala
+++ b/answers/src/main/scala/fpinscala/monads/Monad.scala
@@ -1,7 +1,5 @@
 package fpinscala.answers.monads
 
-import scala.language.higherKinds
-
 import fpinscala.answers.parsing._
 import fpinscala.answers.testing._
 import fpinscala.answers.parallelism._

--- a/answers/src/main/scala/fpinscala/monoids/Monoid.scala
+++ b/answers/src/main/scala/fpinscala/monoids/Monoid.scala
@@ -3,9 +3,6 @@ package fpinscala.answers.monoids
 import fpinscala.answers.parallelism.Nonblocking._
 import fpinscala.answers.parallelism.Nonblocking.Par.toParOps // infix syntax for `Par.map`, `Par.flatMap`, etc
 
-import fpinscala.answers.parallelism.Nonblocking._
-import fpinscala.answers.parallelism.Nonblocking.Par.toParOps // infix syntax for `Par.map`, `Par.flatMap`, etc
-
 trait Monoid[A] {
   def op(a1: A, a2: A): A
   def zero: A

--- a/answers/src/main/scala/fpinscala/monoids/Monoid.scala
+++ b/answers/src/main/scala/fpinscala/monoids/Monoid.scala
@@ -1,7 +1,10 @@
-package fpinscala.monoids
+package fpinscala.answers.monoids
 
-import fpinscala.parallelism.Nonblocking._
-import fpinscala.parallelism.Nonblocking.Par.toParOps // infix syntax for `Par.map`, `Par.flatMap`, etc
+import fpinscala.answers.parallelism.Nonblocking._
+import fpinscala.answers.parallelism.Nonblocking.Par.toParOps // infix syntax for `Par.map`, `Par.flatMap`, etc
+
+import fpinscala.answers.parallelism.Nonblocking._
+import fpinscala.answers.parallelism.Nonblocking.Par.toParOps // infix syntax for `Par.map`, `Par.flatMap`, etc
 
 trait Monoid[A] {
   def op(a1: A, a2: A): A
@@ -69,7 +72,7 @@ object Monoid {
     val zero = (a: A) => a
   }
 
-  import fpinscala.testing._
+  import fpinscala.answers.testing._
   import Prop._
 
   def monoidLaws[A](m: Monoid[A], gen: Gen[A]): Prop =

--- a/answers/src/main/scala/fpinscala/parallelism/Actor.scala
+++ b/answers/src/main/scala/fpinscala/parallelism/Actor.scala
@@ -1,4 +1,4 @@
-package fpinscala.parallelism
+package fpinscala.answers.parallelism
 
 import java.util.concurrent.atomic.{AtomicInteger, AtomicReference}
 import java.util.concurrent.{Callable,ExecutorService}

--- a/answers/src/main/scala/fpinscala/parallelism/Nonblocking.scala
+++ b/answers/src/main/scala/fpinscala/parallelism/Nonblocking.scala
@@ -1,4 +1,4 @@
-package fpinscala.parallelism
+package fpinscala.answers.parallelism
 
 import java.util.concurrent.{Callable, CountDownLatch, ExecutorService}
 import java.util.concurrent.atomic.AtomicReference

--- a/answers/src/main/scala/fpinscala/parallelism/Par.scala
+++ b/answers/src/main/scala/fpinscala/parallelism/Par.scala
@@ -1,4 +1,4 @@
-package fpinscala.parallelism
+package fpinscala.answers.parallelism
 
 import java.util.concurrent._
 

--- a/answers/src/main/scala/fpinscala/parsing/JSON.scala
+++ b/answers/src/main/scala/fpinscala/parsing/JSON.scala
@@ -1,4 +1,4 @@
-package fpinscala.parsing
+package fpinscala.answers.parsing
 
 trait JSON
 
@@ -63,8 +63,8 @@ object JSONExample extends App {
 ]
 """
 
-  val P = fpinscala.parsing.Reference
-  import fpinscala.parsing.ReferenceTypes.Parser
+  val P = fpinscala.answers.parsing.Reference
+  import fpinscala.answers.parsing.ReferenceTypes.Parser
 
   def printResult[E](e: Either[E,JSON]) =
     e.fold(println, println)

--- a/answers/src/main/scala/fpinscala/parsing/Parsers.scala
+++ b/answers/src/main/scala/fpinscala/parsing/Parsers.scala
@@ -1,9 +1,14 @@
-package fpinscala.parsing
+package fpinscala.answers.parsing
+
+import scala.language.implicitConversions
+// import scala.language.postfixOps
+import scala.language.higherKinds
+
 
 import java.util.regex._
 import scala.util.matching.Regex
-import fpinscala.testing._
-import fpinscala.testing.Prop._
+import fpinscala.answers.testing._
+import fpinscala.answers.testing.Prop._
 
 trait Parsers[Parser[+_]] { self => // so inner classes may call methods of trait
   def run[A](p: Parser[A])(input: String): Either[ParseError,A]

--- a/answers/src/main/scala/fpinscala/parsing/Parsers.scala
+++ b/answers/src/main/scala/fpinscala/parsing/Parsers.scala
@@ -1,10 +1,5 @@
 package fpinscala.answers.parsing
 
-import scala.language.implicitConversions
-// import scala.language.postfixOps
-import scala.language.higherKinds
-
-
 import java.util.regex._
 import scala.util.matching.Regex
 import fpinscala.answers.testing._

--- a/answers/src/main/scala/fpinscala/parsing/instances/Reference.scala
+++ b/answers/src/main/scala/fpinscala/parsing/instances/Reference.scala
@@ -1,5 +1,4 @@
-package fpinscala
-package parsing
+package fpinscala.answers.parsing
 
 import ReferenceTypes._
 import scala.util.matching.Regex

--- a/answers/src/main/scala/fpinscala/parsing/instances/Sliceable.scala
+++ b/answers/src/main/scala/fpinscala/parsing/instances/Sliceable.scala
@@ -1,5 +1,4 @@
-package fpinscala
-package parsing
+package fpinscala.answers.parsing
 
 import SliceableTypes._
 import scala.util.matching.Regex

--- a/answers/src/main/scala/fpinscala/state/State.scala
+++ b/answers/src/main/scala/fpinscala/state/State.scala
@@ -1,4 +1,4 @@
-package fpinscala.state
+package fpinscala.answers.state
 
 
 trait RNG {

--- a/answers/src/main/scala/fpinscala/streamingio/Eq.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/Eq.scala
@@ -1,4 +1,4 @@
-package fpinscala.streamingio
+package fpinscala.answers.streamingio
 
 /* 
  * `Eq[A,B]` provides evidence that types `A` and `B` are equal. 

--- a/answers/src/main/scala/fpinscala/streamingio/MonadCatch.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/MonadCatch.scala
@@ -1,6 +1,7 @@
-package fpinscala.streamingio
+package fpinscala.answers.streamingio
 
-import fpinscala.iomonad._
+import fpinscala.answers.monads.Monad
+import fpinscala.answers.iomonad.Task
 
 /*
  * A context in which exceptions can be caught and
@@ -14,7 +15,7 @@ trait MonadCatch[F[_]] extends Monad[F] {
 object MonadCatch {
   implicit def task = new MonadCatch[Task] {
     def unit[A](a: => A): Task[A] = Task.unit(a)
-    def flatMap[A,B](a: Task[A])(f: A => Task[B]): Task[B] = a flatMap f
+    override def flatMap[A,B](a: Task[A])(f: A => Task[B]): Task[B] = a flatMap f
     def attempt[A](a: Task[A]): Task[Either[Throwable,A]] = a.attempt
     def fail[A](err: Throwable): Task[A] = Task.fail(err)
   }

--- a/answers/src/main/scala/fpinscala/streamingio/Partial.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/Partial.scala
@@ -1,4 +1,4 @@
-package fpinscala.streamingio
+package fpinscala.answers.streamingio
 
 /* 
  * A context in which exceptions can be caught and

--- a/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
@@ -1,6 +1,6 @@
-package fpinscala.streamingio
+package fpinscala.answers.streamingio
 
-import fpinscala.iomonad.{IO,Monad,Free,unsafePerformIO}
+import fpinscala.answers.iomonad.{IO,Monad,Free,unsafePerformIO}
 
 object ImperativeAndLazyIO {
 
@@ -244,7 +244,7 @@ object SimpleStreamTransducers {
 
     // Process forms a monad, and we provide monad syntax for it
 
-    import fpinscala.iomonad.Monad
+    import fpinscala.answers.iomonad.Monad
 
     def monad[I]: Monad[({ type f[x] = Process[I,x]})#f] =
       new Monad[({ type f[x] = Process[I,x]})#f] {
@@ -745,7 +745,7 @@ object GeneralizedStreamTransducers {
 
     /* Our generalized `Process` type can represent sources! */
 
-    import fpinscala.iomonad.IO
+    import fpinscala.answers.iomonad.IO
 
     /* Special exception indicating normal termination */
     case object End extends Exception
@@ -774,7 +774,7 @@ object GeneralizedStreamTransducers {
           case Halt(err) => throw err
           case Await(req,recv) =>
             val next =
-              try recv(Right(fpinscala.iomonad.unsafePerformIO(req)(E)))
+              try recv(Right(fpinscala.answers.iomonad.unsafePerformIO(req)(E)))
               catch { case err: Throwable => recv(Left(err)) }
             go(next, acc)
         }
@@ -1015,7 +1015,7 @@ object GeneralizedStreamTransducers {
      * convert the lines of a file from fahrenheit to celsius.
      */
 
-    import fpinscala.iomonad.IO0.fahrenheitToCelsius
+    import fpinscala.answers.iomonad.IO0.fahrenheitToCelsius
 
     val converter: Process[IO,Unit] =
       lines("fahrenheit.txt").
@@ -1115,7 +1115,7 @@ object GeneralizedStreamTransducers {
 
 object ProcessTest extends App {
   import GeneralizedStreamTransducers._
-  import fpinscala.iomonad.IO
+  import fpinscala.answers.iomonad.IO
   import Process._
 
   val p = eval(IO { println("woot"); 1 }).repeat

--- a/answers/src/main/scala/fpinscala/streamingio/These.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/These.scala
@@ -1,4 +1,4 @@
-package fpinscala.streamingio
+package fpinscala.answers.streamingio
 
 /* Data type representing either A, B, or both A and B. */
 trait These[+A,+B] {

--- a/answers/src/main/scala/fpinscala/testing/Exhaustive.scala
+++ b/answers/src/main/scala/fpinscala/testing/Exhaustive.scala
@@ -1,4 +1,4 @@
-package fpinscala.testing.exhaustive
+package fpinscala.answers.testing.exhaustive
 
 /*
 This source file contains the answers to the last two exercises in the section
@@ -7,10 +7,11 @@ This source file contains the answers to the last two exercises in the section
 The Gen data type in this file incorporates exhaustive checking of finite domains.
 */
 
-import fpinscala.laziness.{Stream,Cons,Empty}
-import fpinscala.state._
-import fpinscala.parallelism._
-import fpinscala.parallelism.Par.Par
+
+import fpinscala.answers.laziness.{Stream,Cons,Empty}
+import fpinscala.answers.state._
+import fpinscala.answers.parallelism._
+import fpinscala.answers.parallelism.Par.Par
 import Gen._
 import Prop._
 import Status._

--- a/answers/src/main/scala/fpinscala/testing/Gen.scala
+++ b/answers/src/main/scala/fpinscala/testing/Gen.scala
@@ -1,9 +1,9 @@
-package fpinscala.testing
+package fpinscala.answers.testing
 
-import fpinscala.laziness.Stream
-import fpinscala.state._
-import fpinscala.parallelism._
-import fpinscala.parallelism.Par.Par
+import fpinscala.answers.laziness.Stream
+import fpinscala.answers.state._
+import fpinscala.answers.parallelism._
+import fpinscala.answers.parallelism.Par.Par
 import Gen._
 import Prop._
 import java.util.concurrent.{Executors,ExecutorService}


### PR DESCRIPTION
This was necessary to solve errors given by Ensime for Emacs.  With answers and exercises in the same package, Ensime showed lots of duplicate code errors.  Ensime's project-wide typechecker (`M-x ensime-typecheck-all`) does not stay within an SBT subproject.  This is written up here:  https://github.com/ensime/ensime-server/issues/867

Moving all answers code into package `fpinscala.answers` completely solved the problem.
