### PR TITLE
Switched time measurement to nanoseconds

### DIFF
--- a/answerkey/parallelism/03.answer.scala
+++ b/answerkey/parallelism/03.answer.scala
@@ -17,15 +17,15 @@ case class Map2Future[A,B,C](a: Future[A], b: Future[B],
     a.cancel(evenIfRunning) || b.cancel(evenIfRunning)
   def get = compute(Long.MaxValue)
   def get(timeout: Long, units: TimeUnit): C =
-    compute(TimeUnit.MILLISECONDS.convert(timeout, units))
+    compute(TimeUnit.NANOSECONDS.convert(timeout, units))
 
-  private def compute(timeoutMs: Long): C = cache match {
+  private def compute(timeoutInNanos: Long): C = cache match {
     case Some(c) => c
     case None =>
-      val start = System.currentTimeMillis
-      val ar = a.get(timeoutMs, TimeUnit.MILLISECONDS)
-      val stop = System.currentTimeMillis; val at = stop-start
-      val br = b.get(timeoutMs - at, TimeUnit.MILLISECONDS)
+      val start = System.nanoTime
+      val ar = a.get(timeoutInNanos, TimeUnit.NANOSECONDS)
+      val stop = System.nanoTime;val aTime = stop-start
+      val br = b.get(timeoutInNanos - aTime, TimeUnit.NANOSECONDS)
       val ret = f(ar, br)
       cache = Some(ret)
       ret


### PR DESCRIPTION
In order to avoid using System.currentTimeMillis for measuring time, the answer to 7.3 now uses `System.nanoTime` for measuring durations

This addresses #420.