### PR TITLE
Laziness chapter answers, a simpler zipAll

### DIFF
--- a/answers/src/main/scala/fpinscala/laziness/Stream.scala
+++ b/answers/src/main/scala/fpinscala/laziness/Stream.scala
@@ -140,8 +140,16 @@ trait Stream[+A] {
   def zip[B](s2: Stream[B]): Stream[(A,B)] =
     zipWith(s2)((_,_))
 
+  def zipAll[B](s2: Stream[B]): Stream[(Option[A],Option[B])] = {
+    unfold((this,s2)) {
+      case((Empty, Empty)) => None
+      case ((Empty, Cons(h,t))) => Some(((None, Some(h())),(Empty, t())))
+      case ((Cons(h,t), Empty)) => Some(((Some(h()), None),(t(), Empty)))
+      case ((Cons(h1,t1), Cons(h2, t2))) =>Some(( (Some(h1()), Some(h2())), (t1(), t2())))
+    }
+  }
 
-  def zipAll[B](s2: Stream[B]): Stream[(Option[A],Option[B])] =
+  def zipAllViaZipWithAll[B](s2: Stream[B]): Stream[(Option[A],Option[B])] =
     zipWithAll(s2)((_,_))
 
   def zipWithAll[B, C](s2: Stream[B])(f: (Option[A], Option[B]) => C): Stream[C] =


### PR DESCRIPTION
that doesn't rely on zipWithAll with its use of the slim arrow operator.

zipWithAll is not mentioned in the book until page 354 in the context of List. The -> operator is not used in the book until later on page 168 and is hard to Google for, which makes zipWithAll a bit difficult to understand.
