### PR TITLE
Curried monoidLaws, so type inference works better when using it.

### DIFF
--- a/answerkey/monoids/04.answer.scala
+++ b/answerkey/monoids/04.answer.scala
@@ -1,7 +1,7 @@
 import fpinscala.testing._
 import Prop._
 
-def monoidLaws[A](m: Monoid[A], gen: Gen[A]): Prop =
+def monoidLaws[A](gen: Gen[A])(m: Monoid[A]): Prop =
   // Associativity
   forAll(for {
     x <- gen

--- a/answers/src/main/scala/fpinscala/monoids/Monoid.scala
+++ b/answers/src/main/scala/fpinscala/monoids/Monoid.scala
@@ -72,7 +72,7 @@ object Monoid {
   import fpinscala.testing._
   import Prop._
 
-  def monoidLaws[A](m: Monoid[A], gen: Gen[A]): Prop =
+  def monoidLaws[A](gen: Gen[A])(m: Monoid[A]): Prop =
     // Associativity
     forAll(for {
       x <- gen

--- a/exercises/src/main/scala/fpinscala/monoids/Monoid.scala
+++ b/exercises/src/main/scala/fpinscala/monoids/Monoid.scala
@@ -41,7 +41,7 @@ object Monoid {
 
   import fpinscala.testing._
   import Prop._
-  def monoidLaws[A](m: Monoid[A], gen: Gen[A]): Prop = sys.error("todo")
+  def monoidLaws[A](gen: Gen[A])(m: Monoid[A]): Prop = sys.error("todo")
 
   def trimMonoid(s: String): Monoid[String] = sys.error("todo")
 


### PR DESCRIPTION
Type inference works better on actual usage:

import fpinscala.monoids.Monoid._
import fpinscala.testing.Prop._
import fpinscala.testing.Gen

object MonoidSpec extends App {

  private val smallInt: Gen[Int] = Gen.choose(-50, 50)
  run(monoidLaws(smallInt)(intAddition))

  run(monoidLaws(smallInt)(intMultiplication))

  run(monoidLaws(Gen.boolean)(booleanOr))

  run(monoidLaws(Gen.boolean)(booleanAnd))

  private val optionGen: Gen[Option[Int]] = Gen.boolean *\* smallInt map {
    case (b, i) => if (b) Some(i) else None
  }
  run(monoidLaws(optionGen)(optionMonoid))
}
