### PR TITLE
Fix compiler warnings and bump scala version to 2.11.7

### DIFF
--- a/answers/src/main/scala/fpinscala/applicative/Applicative.scala
+++ b/answers/src/main/scala/fpinscala/applicative/Applicative.scala
@@ -5,6 +5,9 @@ import monads.Functor
 import state._
 import State._
 import monoids._
+import language.higherKinds
+import language.implicitConversions
+
 
 trait Applicative[F[_]] extends Functor[F] {
   // `map2` is implemented by first currying `f` so we get a function

--- a/answers/src/main/scala/fpinscala/iomonad/BindTest.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/BindTest.scala
@@ -1,5 +1,8 @@
 package fpinscala.iomonad
 
+import language.higherKinds
+import language.postfixOps
+
 object BindTest extends App {
 
   def timeit(n: Int)(task: => Unit): Unit = {

--- a/answers/src/main/scala/fpinscala/iomonad/IO.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/IO.scala
@@ -1,5 +1,9 @@
 package fpinscala.iomonad
 
+import scala.io.StdIn.readLine
+import language.higherKinds
+import language.postfixOps
+
 object IO0 {
                             /*
 

--- a/answers/src/main/scala/fpinscala/iomonad/Monad.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/Monad.scala
@@ -1,6 +1,7 @@
 package fpinscala.iomonad
 
 import language.higherKinds // Disable warnings for type constructor polymorphism
+import language.implicitConversions
 
 trait Functor[F[_]] {
   def map[A,B](a: F[A])(f: A => B): F[B]

--- a/answers/src/main/scala/fpinscala/iomonad/package.scala
+++ b/answers/src/main/scala/fpinscala/iomonad/package.scala
@@ -1,5 +1,7 @@
 package fpinscala
 
+import language.higherKinds
+
 package object iomonad {
   import fpinscala.parallelism.Nonblocking._
 

--- a/answers/src/main/scala/fpinscala/monads/Monad.scala
+++ b/answers/src/main/scala/fpinscala/monads/Monad.scala
@@ -6,6 +6,8 @@ import testing._
 import parallelism._
 import state._
 import parallelism.Par._
+import language.higherKinds
+
 
 trait Functor[F[_]] {
   def map[A,B](fa: F[A])(f: A => B): F[B]

--- a/answers/src/main/scala/fpinscala/monoids/Monoid.scala
+++ b/answers/src/main/scala/fpinscala/monoids/Monoid.scala
@@ -2,6 +2,7 @@ package fpinscala.monoids
 
 import fpinscala.parallelism.Nonblocking._
 import fpinscala.parallelism.Nonblocking.Par.toParOps // infix syntax for `Par.map`, `Par.flatMap`, etc
+import language.higherKinds
 
 trait Monoid[A] {
   def op(a1: A, a2: A): A

--- a/answers/src/main/scala/fpinscala/parallelism/Nonblocking.scala
+++ b/answers/src/main/scala/fpinscala/parallelism/Nonblocking.scala
@@ -2,6 +2,7 @@ package fpinscala.parallelism
 
 import java.util.concurrent.{Callable, CountDownLatch, ExecutorService}
 import java.util.concurrent.atomic.AtomicReference
+import language.implicitConversions
 
 object Nonblocking {
 

--- a/answers/src/main/scala/fpinscala/parallelism/Par.scala
+++ b/answers/src/main/scala/fpinscala/parallelism/Par.scala
@@ -1,6 +1,8 @@
 package fpinscala.parallelism
 
 import java.util.concurrent._
+import language.implicitConversions
+
 
 object Par {
   type Par[A] = ExecutorService => Future[A]

--- a/answers/src/main/scala/fpinscala/parsing/JSON.scala
+++ b/answers/src/main/scala/fpinscala/parsing/JSON.scala
@@ -1,5 +1,8 @@
 package fpinscala.parsing
 
+import language.higherKinds
+import language.implicitConversions
+
 trait JSON
 
 object JSON {

--- a/answers/src/main/scala/fpinscala/parsing/Parsers.scala
+++ b/answers/src/main/scala/fpinscala/parsing/Parsers.scala
@@ -4,6 +4,8 @@ import java.util.regex._
 import scala.util.matching.Regex
 import fpinscala.testing._
 import fpinscala.testing.Prop._
+import language.higherKinds
+import language.implicitConversions
 
 trait Parsers[Parser[+_]] { self => // so inner classes may call methods of trait
   def run[A](p: Parser[A])(input: String): Either[ParseError,A]

--- a/answers/src/main/scala/fpinscala/streamingio/MonadCatch.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/MonadCatch.scala
@@ -2,6 +2,8 @@ package fpinscala.streamingio
 
 import fpinscala.iomonad._
 
+import language.higherKinds
+
 /*
  * A context in which exceptions can be caught and
  * thrown.

--- a/answers/src/main/scala/fpinscala/streamingio/Partial.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/Partial.scala
@@ -1,5 +1,7 @@
 package fpinscala.streamingio
 
+import language.higherKinds
+
 /* 
  * A context in which exceptions can be caught and
  * thrown. 

--- a/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
@@ -1,6 +1,9 @@
 package fpinscala.streamingio
 
 import fpinscala.iomonad.{IO,Monad,Free,unsafePerformIO}
+import language.implicitConversions
+import language.higherKinds
+import language.postfixOps
 
 object ImperativeAndLazyIO {
 

--- a/answers/src/main/scala/fpinscala/streamingio/These.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/These.scala
@@ -1,5 +1,7 @@
 package fpinscala.streamingio
 
+import language.postfixOps
+
 /* Data type representing either A, B, or both A and B. */
 trait These[+A,+B] {
   import These._

--- a/answers/src/main/scala/fpinscala/testing/Exhaustive.scala
+++ b/answers/src/main/scala/fpinscala/testing/Exhaustive.scala
@@ -1,5 +1,8 @@
 package fpinscala.testing.exhaustive
 
+import language.implicitConversions
+import language.postfixOps
+
 /*
 This source file contains the answers to the last two exercises in the section
 "Test Case Minimization" of chapter 8 on property-based testing.

--- a/answers/src/main/scala/fpinscala/testing/Gen.scala
+++ b/answers/src/main/scala/fpinscala/testing/Gen.scala
@@ -7,6 +7,8 @@ import fpinscala.parallelism.Par.Par
 import Gen._
 import Prop._
 import java.util.concurrent.{Executors,ExecutorService}
+import language.postfixOps
+import language.implicitConversions
 
 case class Prop(run: (MaxSize,TestCases,RNG) => Result) {
   def &&(p: Prop) = Prop {

--- a/exercises/src/main/scala/fpinscala/applicative/Applicative.scala
+++ b/exercises/src/main/scala/fpinscala/applicative/Applicative.scala
@@ -6,6 +6,8 @@ import state._
 import State._
 import StateUtil._ // defined at bottom of this file
 import monoids._
+import language.higherKinds
+import language.implicitConversions
 
 trait Applicative[F[_]] extends Functor[F] {
 

--- a/exercises/src/main/scala/fpinscala/iomonad/IO.scala
+++ b/exercises/src/main/scala/fpinscala/iomonad/IO.scala
@@ -1,5 +1,9 @@
 package fpinscala.iomonad
 
+import language.postfixOps
+import language.higherKinds
+import scala.io.StdIn.readLine
+
 object IO0 {
                             /*
 

--- a/exercises/src/main/scala/fpinscala/iomonad/Monad.scala
+++ b/exercises/src/main/scala/fpinscala/iomonad/Monad.scala
@@ -1,6 +1,7 @@
 package fpinscala.iomonad
 
 import language.higherKinds // Disable warnings for type constructor polymorphism
+import language.implicitConversions
 
 trait Functor[F[_]] {
   def map[A,B](a: F[A])(f: A => B): F[B]

--- a/exercises/src/main/scala/fpinscala/iomonad/package.scala
+++ b/exercises/src/main/scala/fpinscala/iomonad/package.scala
@@ -1,5 +1,7 @@
 package fpinscala
 
+import language.higherKinds
+
 package object iomonad {
   import fpinscala.parallelism.Nonblocking._
 

--- a/exercises/src/main/scala/fpinscala/monads/Monad.scala
+++ b/exercises/src/main/scala/fpinscala/monads/Monad.scala
@@ -6,6 +6,8 @@ import testing._
 import parallelism._
 import state._
 import parallelism.Par._
+import language.higherKinds
+
 
 trait Functor[F[_]] {
   def map[A,B](fa: F[A])(f: A => B): F[B]

--- a/exercises/src/main/scala/fpinscala/monoids/Monoid.scala
+++ b/exercises/src/main/scala/fpinscala/monoids/Monoid.scala
@@ -2,6 +2,7 @@ package fpinscala.monoids
 
 import fpinscala.parallelism.Nonblocking._
 import fpinscala.parallelism.Nonblocking.Par.toParOps // infix syntax for `Par.map`, `Par.flatMap`, etc
+import language.higherKinds
 
 trait Monoid[A] {
   def op(a1: A, a2: A): A

--- a/exercises/src/main/scala/fpinscala/parallelism/Nonblocking.scala
+++ b/exercises/src/main/scala/fpinscala/parallelism/Nonblocking.scala
@@ -2,6 +2,7 @@ package fpinscala.parallelism
 
 import java.util.concurrent.{Callable, CountDownLatch, ExecutorService}
 import java.util.concurrent.atomic.AtomicReference
+import language.implicitConversions
 
 object Nonblocking {
 

--- a/exercises/src/main/scala/fpinscala/parallelism/Par.scala
+++ b/exercises/src/main/scala/fpinscala/parallelism/Par.scala
@@ -1,6 +1,7 @@
 package fpinscala.parallelism
 
 import java.util.concurrent._
+import language.implicitConversions
 
 object Par {
   type Par[A] = ExecutorService => Future[A]

--- a/exercises/src/main/scala/fpinscala/parsing/Parsers.scala
+++ b/exercises/src/main/scala/fpinscala/parsing/Parsers.scala
@@ -1,9 +1,6 @@
 package fpinscala.parsing
 
-import java.util.regex._
-import scala.util.matching.Regex
-import fpinscala.testing._
-import fpinscala.testing.Prop._
+import language.higherKinds
 
 trait Parsers[Parser[+_]] { self => // so inner classes may call methods of trait
 

--- a/exercises/src/main/scala/fpinscala/streamingio/MonadCatch.scala
+++ b/exercises/src/main/scala/fpinscala/streamingio/MonadCatch.scala
@@ -1,6 +1,7 @@
 package fpinscala.streamingio
 
 import fpinscala.iomonad._
+import language.higherKinds
 
 /*
  * A context in which exceptions can be caught and

--- a/exercises/src/main/scala/fpinscala/streamingio/StreamingIO.scala
+++ b/exercises/src/main/scala/fpinscala/streamingio/StreamingIO.scala
@@ -1,6 +1,9 @@
 package fpinscala.streamingio
 
 import fpinscala.iomonad.{IO,Monad,Free,unsafePerformIO}
+import language.implicitConversions
+import language.higherKinds
+import language.postfixOps
 
 object ImperativeAndLazyIO {
 

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -3,7 +3,7 @@ import Keys._
 
 object FPInScalaBuild extends Build {
   val opts = Project.defaultSettings ++ Seq(
-    scalaVersion := "2.11.5",
+    scalaVersion := "2.11.7",
     resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
   )
 


### PR DESCRIPTION
Remove compiler warnings by adding imports for language features (higherKinds, implicitConversions, postfixOps) and remove use of deprecated `readLine` method by importing `StdIn.readLine`.

Bump Scala version to 2.11.7.