### PR TITLE
Improve support for IntelliJ

### DIFF
--- a/answers/src/main/scala/fpinscala/parsing/JSON.scala
+++ b/answers/src/main/scala/fpinscala/parsing/JSON.scala
@@ -11,10 +11,11 @@ object JSON {
   case class JObject(get: Map[String, JSON]) extends JSON
 
   def jsonParser[Parser[+_]](P: Parsers[Parser]): Parser[JSON] = {
-    // we'll hide the string implicit conversion and promote strings to tokens instead
+    import P._
+
+    // we'll shadow the string implicit conversion from the Parsers trait and promote strings to tokens instead
     // this is a bit nicer than having to write token everywhere
-    import P.{string => _, _}
-    implicit def tok(s: String) = token(P.string(s))
+    implicit def string(s: String): Parser[String] = token(P.string(s))
 
     def array = surround("[","]")(
       value sep "," map (vs => JArray(vs.toIndexedSeq))) scope "array"


### PR DESCRIPTION
IntelliJ gets confused with the syntax:

import P.{string => _, _}

resulting in fake highlighting errors in the editor after this line.

"Shadowing" string works better and eliminates the highlighting errors, making it more pleasant to experiment with the JSON parsing code.

Not tested if this also happens with the ScalaIDE...
