### PR TITLE
Sbt update autoplugin support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -10,3 +10,5 @@ project.vim
 .project
 .classpath
 .metadata/
+.ensime
+.ensime_cache/

--- a/project/Build.scala
+++ b/project/Build.scala
@@ -2,7 +2,7 @@ import sbt._
 import Keys._
 
 object FPInScalaBuild extends Build {
-  val opts = Project.defaultSettings ++ Seq(
+  val opts = Seq(
     scalaVersion := "2.11.7",
     resolvers += "Typesafe Repository" at "http://repo.typesafe.com/typesafe/releases/"
   )

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.9


### PR DESCRIPTION
This pull request concerns sbt and the removal of a deprecation in Build.scala which makes sbt's AutoPlugins work (adds ENSIME support).

I tried to use ENSIME to work with the code in this project, however using the latest version of the sbt-ensime plugin does not seem to be compatible with the current sbt setup of fpinscala.

The reason for this is that Build.scala uses a deprecated method which may cause sbt AutoPlugins not to work correctly.

In this pull request I fix this issue and propose to fix the version of sbt used to build this project as there seem to be differences in behavior in 0.13 versions of sbt.

To reproduce I followed the instructions described on the [ENSIME setup page](https://ensime.github.io/build_tools/sbt/):
- add `addSbtPlugin("org.ensime" % "ensime-sbt" % "0.3.2")` to  `~/.sbt/0.13/plugins/plugins.sbt`
- generate the `.ensime` file using `sbt gen-ensime`

Doing this I ran into: 

```
java.lang.IllegalArgumentException: Cannot add dependency 'org.scala-lang#scala-compiler;2.11.7' to configuration 'ensime-internal' of module fpinscala#fpinscala_2.11;0.1-SNAPSHOT because this configuration doesn't exist!
...
```

which has been reported and documented at sbt-ensime [here](https://github.com/ensime/ensime-sbt/issues/145) 

Turns out the cause for this error is usually in the projects using the plugin, in the case of `fpinscala` more specifically the use of the since sbt 0.13.2 deprecated `Project.defaultSettings` in  `Build.scala` [here](https://github.com/fpinscala/fpinscala/blob/master/project/Build.scala#L5). 
Not fixing may cause sbt AutoPlugins not to load correctly as mentioned [here](https://groups.google.com/d/msg/scala-tools/uuFsGN1DhNs/JRQdaCUKUjAJ) which is the case for the `sbt-ensime` plugin.

What I did for this pull request is remove this deprecated field because in current sbt versions it is only needed to _add_ your own settings in your build definition. 

Because of the difference in behavior between older and current sbt versions I would also recommend to specify a fixed version for sbt. This way all users of this repo use the same sbt version transparently and AutoPlugins work.

If more clarification is needed please let me know and I'll try to update this request.

KR,

Hans
