### PR TITLE
exercise 7.5: bug-fix: sequenceRight should call /itself/ in 0.5.answ…

### DIFF
--- a/answerkey/parallelism/05.answer.scala
+++ b/answerkey/parallelism/05.answer.scala
@@ -9,7 +9,7 @@ def sequence_simple[A](l: List[Par[A]]): Par[List[A]] =
 def sequenceRight[A](as: List[Par[A]]): Par[List[A]] = 
   as match {
     case Nil => unit(Nil)
-    case h :: t => map2(h, fork(sequence(t)))(_ :: _)
+    case h :: t => map2(h, fork(sequenceRight(t)))(_ :: _)
   }
 
 // We define `sequenceBalanced` using `IndexedSeq`, which provides an 

--- a/answers/src/main/scala/fpinscala/parallelism/Par.scala
+++ b/answers/src/main/scala/fpinscala/parallelism/Par.scala
@@ -51,7 +51,7 @@ object Par {
   def sequenceRight[A](as: List[Par[A]]): Par[List[A]] =
     as match {
       case Nil => unit(Nil)
-      case h :: t => map2(h, fork(sequence(t)))(_ :: _)
+      case h :: t => map2(h, fork(sequenceRight(t)))(_ :: _)
     }
 
   // We define `sequenceBalanced` using `IndexedSeq`, which provides an


### PR DESCRIPTION
…er.scala, Par.scala

```
def sequenceRight[A](as: List[Par[A]]): Par[List[A]] =
  as match {
    case Nil => unit(Nil)
-   case h :: t => map2(h, fork(sequence(t)))(_ :: _)
+   case h :: t => map2(h, fork(sequenceRight(t)))(_ :: _)
```