### PR TITLE
Fix Halt().repeat repeating forever.

### DIFF
--- a/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
@@ -184,7 +184,10 @@ object SimpleStreamTransducers {
         }
         case Emit(h, t) => Emit(h, go(t))
       }
-      go(this)
+      this match {
+        case Halt() => this
+        case _ => go(this)
+      }
     }
 
     def repeatN(n: Int): Process[I,O] = {


### PR DESCRIPTION
``` scala
scala> val a = fpinscala.streamingio.SimpleStreamTransducers.Process.Halt[Int, String]()
a: fpinscala.streamingio.SimpleStreamTransducers.Process.Halt[Int,String] = Halt()

scala> val b = a.repeat
b: fpinscala.streamingio.SimpleStreamTransducers.Process[Int,String] = Halt()
```
