### PR TITLE
Fix bug in unfoldViaFold and unfoldViaMap 

### DIFF
--- a/answers/src/main/scala/fpinscala/laziness/Stream.scala
+++ b/answers/src/main/scala/fpinscala/laziness/Stream.scala
@@ -235,10 +235,10 @@ object Stream {
   The below two implementations use `fold` and `map` functions in the Option class to implement unfold, thereby doing away with the need to manually pattern match as in the above solution.
    */
   def unfoldViaFold[A, S](z: S)(f: S => Option[(A, S)]): Stream[A] =
-    f(z).fold(empty[A])((p: (A,S)) => cons(p._1,unfold(p._2)(f)))
+    f(z).fold(empty[A])((p: (A,S)) => cons(p._1,unfoldViaFold(p._2)(f)))
 
   def unfoldViaMap[A, S](z: S)(f: S => Option[(A, S)]): Stream[A] =
-    f(z).map((p: (A,S)) => cons(p._1,unfold(p._2)(f))).getOrElse(empty[A])
+    f(z).map((p: (A,S)) => cons(p._1,unfoldViaMap(p._2)(f))).getOrElse(empty[A])
 
   /*
   Scala provides shorter syntax when the first action of a function literal is to match on an expression.  The function passed to `unfold` in `fibsViaUnfold` is equivalent to `p => p match { case (f0,f1) => ... }`, but we avoid having to choose a name for `p`, only to pattern match on it.


### PR DESCRIPTION
This PR fixes a bug in unfoldViaFold and unfoldViaMap where the recursive call is calling unfold instead of the defined functions.
