### PR TITLE
Removed imports so that the trait compiles

### DIFF
--- a/answers/src/main/scala/fpinscala/errorhandling/Option.scala
+++ b/answers/src/main/scala/fpinscala/errorhandling/Option.scala
@@ -1,8 +1,5 @@
 package fpinscala.errorhandling
 
-//hide std library `Option` and `Either`, since we are writing our own in this chapter
-import scala.{Option => _, Either => _, _}
-
 sealed trait Option[+A] {
   def map[B](f: A => B): Option[B] = this match {
     case None => None


### PR DESCRIPTION
The trait was not compiling as long as the imports in order to hide the implementations were there. Thus removed the imports. Scala sdk version: 2.11.7