### PR TITLE
Add test stubs

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,8 @@
 val commonSettings = Seq(
-  scalaVersion := "2.12.1"
+  scalaVersion := "2.12.1",
+  libraryDependencies ++= Seq(
+    "org.scalatest" %% "scalatest" % "3.0.1" % Test
+  )
 )
 
 lazy val root = (project in file("."))

--- a/exercises/src/test/scala/fpinscala/applicative/ApplicativeTest.scala
+++ b/exercises/src/test/scala/fpinscala/applicative/ApplicativeTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.applicative
+
+import org.scalatest.{FunSuite, Matchers}
+
+
+class ApplicativeTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/datastructures/DatastructuresTest.scala
+++ b/exercises/src/test/scala/fpinscala/datastructures/DatastructuresTest.scala
@@ -1,0 +1,10 @@
+package fpinscala.datastructures
+
+import org.scalatest.{FunSuite, Matchers}
+
+import scala.{List => _, Nil => _, _}  // hide std library `List`, since we are writing our own in this chapter
+
+
+class DatastructuresTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/errorhandling/ErrorHandlingTest.scala
+++ b/exercises/src/test/scala/fpinscala/errorhandling/ErrorHandlingTest.scala
@@ -1,0 +1,10 @@
+package fpinscala.errorhandling
+
+import org.scalatest.{FunSuite, Matchers}
+
+import scala.{Either => _, Left => _, Right => _, Option => _, None => _, Some => _, _} // hide std library `Option` and `Either`, since we are writing our own in this chapter
+
+
+class ErrorHandlingTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/gettingstarted/GettingStartedTest.scala
+++ b/exercises/src/test/scala/fpinscala/gettingstarted/GettingStartedTest.scala
@@ -26,6 +26,8 @@ class GettingStartedTest extends FunSuite with Matchers {
   }
 
   test("some property of fib is true") {
-    MyModule.fib(0) // shouldEqual <something>
+    // test some property of MyModule.fib(<int>)
   }
+
+  // etc
 }

--- a/exercises/src/test/scala/fpinscala/gettingstarted/GettingStartedTest.scala
+++ b/exercises/src/test/scala/fpinscala/gettingstarted/GettingStartedTest.scala
@@ -1,0 +1,31 @@
+package fpinscala.gettingstarted
+
+import org.scalatest.{FunSuite, Matchers}
+
+
+/**
+  * You can write tests for your implementations using scalatest.
+  *
+  * The scalatest library provides lots of ways to test your code, the
+  * documentation has more information
+  * http://www.scalatest.org/user_guide/using_matchers
+  *
+  * You can run the tests from the `sbt` console with the `test` command.
+  */
+class GettingStartedTest extends FunSuite with Matchers {
+  test("factorial of 0 is 1") {
+    MyModule.factorial(0) shouldEqual 1
+  }
+
+  test("factorial of 1 is 1") {
+    MyModule.factorial(1) shouldEqual 1
+  }
+
+  test("factorial of 10 is 3628800") {
+    MyModule.factorial(10) shouldEqual 3628800
+  }
+
+  test("some property of fib is true") {
+    MyModule.fib(0) // shouldEqual <something>
+  }
+}

--- a/exercises/src/test/scala/fpinscala/iomonad/IOMonadTest.scala
+++ b/exercises/src/test/scala/fpinscala/iomonad/IOMonadTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.iomonad
+
+import org.scalatest.{FunSuite, Matchers}
+
+
+class IOMonadTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/laziness/LazinessTest.scala
+++ b/exercises/src/test/scala/fpinscala/laziness/LazinessTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.laziness
+
+import org.scalatest.{FunSuite, Matchers}
+
+
+class LazinessTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/localeffects/LocalEffectsTest.scala
+++ b/exercises/src/test/scala/fpinscala/localeffects/LocalEffectsTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.localeffects
+
+import org.scalatest.{FunSuite, Matchers}
+
+
+class LocalEffectsTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/monads/MonadsTest.scala
+++ b/exercises/src/test/scala/fpinscala/monads/MonadsTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.monads
+
+import org.scalatest.{FunSuite, Matchers}
+
+
+class MonadsTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/monoids/MonoidsTest.scala
+++ b/exercises/src/test/scala/fpinscala/monoids/MonoidsTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.monoids
+
+import org.scalatest.{FunSuite, Matchers}
+
+
+class MonoidsTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/parallelism/ParallelismTest.scala
+++ b/exercises/src/test/scala/fpinscala/parallelism/ParallelismTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.parallelism
+
+import org.scalatest.FunSuite
+
+
+class ParallelismTest extends FunSuite {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/parsing/ParsingTest.scala
+++ b/exercises/src/test/scala/fpinscala/parsing/ParsingTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.parsing
+
+import org.scalatest.FunSuite
+
+
+class ParsingTest extends FunSuite {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/state/StateTest.scala
+++ b/exercises/src/test/scala/fpinscala/state/StateTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.state
+
+import org.scalatest.{FunSuite, Matchers}
+
+
+class StateTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/streamingio/StreamingIOTest.scala
+++ b/exercises/src/test/scala/fpinscala/streamingio/StreamingIOTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.streamingio
+
+import org.scalatest.{FunSuite, Matchers}
+
+
+class StreamingIOTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}

--- a/exercises/src/test/scala/fpinscala/testing/TestingTest.scala
+++ b/exercises/src/test/scala/fpinscala/testing/TestingTest.scala
@@ -1,0 +1,8 @@
+package fpinscala.testing
+
+import org.scalatest.{FunSuite, Matchers}
+
+
+class TestingTest extends FunSuite with Matchers {
+  // fill in tests for the functions you implement
+}


### PR DESCRIPTION
While working through the book with people new to Scala I've noticed that people struggle with running the functions they have implemented. This is particularly true of chapters where they implement functions that replace those in the standard library and choosing the correct imports is important (e.g. `List.tail`).
The project is also likely to be many people's first experience of Scala so it's helpful to encourage good practices by making them easy.

By introducing a scalatest dependency and creating a stub test suite for each chapter we provide a more convenient way for people to run their implementations while also introducing them to writing tests in Scala.
