### PR TITLE
Revise a bug on length in `firstNotMatchingIndex`

### DIFF
--- a/answers/src/main/scala/fpinscala/parsing/instances/Reference.scala
+++ b/answers/src/main/scala/fpinscala/parsing/instances/Reference.scala
@@ -50,17 +50,21 @@ object ReferenceTypes {
   case class Success[+A](get: A, length: Int) extends Result[A]
   case class Failure(get: ParseError, isCommitted: Boolean) extends Result[Nothing]
 
-  /** Returns -1 if s1.startsWith(s2), otherwise returns the
-    * first index where the two strings differed. If s2 is
-    * longer than s1, returns s1.length. */
   def firstNonmatchingIndex(s1: String, s2: String, offset: Int): Int = {
-    var i = 0
-    while (i < s1.length && i < s2.length) {
-      if (s1.charAt(i+offset) != s2.charAt(i)) return i
-      i += 1
+    def loop(idx: Int): Int = {
+      val s1Idx = idx + offset
+      val s2Idx = idx
+
+      if (s2Idx >= s2.length) -1
+      else if (s1Idx >= s1.length) s2Idx
+      else {
+        val charS1 = s1.charAt(s1Idx)
+        val charS2 = s2.charAt(s2Idx)
+        if (charS1 == charS2) loop(s2Idx + 1)
+        else s2Idx
+      }
     }
-    if (s1.length-offset >= s2.length) -1
-    else s1.length-offset
+    loop(0)
   }
 }
 


### PR DESCRIPTION
The original implementation of `firstNotmatchingIndex` will fail when `i + offset`  is larger than `s1.length`.

Failed test case:
``` scala
  test("firstNonmatchingIndex 8") {
    val s1 = "hello"
    val s2 = "hello"
    val offset = 9
    val expected = 0
    val actual = ReferenceTypes.firstNonmatchingIndex(s1, s2, offset)
    assert(actual == expected)
  }
```

An `StringIndexOutOfBoundException` will be thrown.
```
[info] - firstNonmatchingIndex 8 *** FAILED ***
[info]   java.lang.StringIndexOutOfBoundsException: String index out of range: 9      
[info]   at java.lang.String.charAt(String.java:658)
[info]   ...                            
```