### PR TITLE
Enable function do deal with arrays being sorted in descending order

### DIFF
--- a/answers/src/main/scala/fpinscala/gettingstarted/GettingStarted.scala
+++ b/answers/src/main/scala/fpinscala/gettingstarted/GettingStarted.scala
@@ -138,7 +138,7 @@ object PolymorphicFunctions {
     @annotation.tailrec
     def go(n: Int): Boolean =
       if (n >= as.length-1) true
-      else if (gt(as(n), as(n+1))) false
+      else if (!gt(as(n), as(n+1))) false
       else go(n+1)
 
     go(0)


### PR DESCRIPTION
When invoking this function e. g. like this: 

`isSorted(Array(1, 3, 5, 7), (x: Int, y: Int) => x > y) //evaluates to TRUE`

I would expect it to be evaluated to **false** (not true) because the array is not being sorted in descending order (7,5,3,1)

```
 //Array sorted in descending order ">" as sorting-operator
scala> List(10, 5, 8, 1, 7).sortWith(_ > _)
res2: List[Int] = List(10, 8, 7, 5, 1)
```

Being a polymorphic function it should work both ways (i.e. descending and ascending) . 
This can be solved by negating the predicate inside the function. 