### PR TITLE
Added a definition of toList for Exercise 5.1

### DIFF
--- a/exercises/src/main/scala/fpinscala/laziness/Stream.scala
+++ b/exercises/src/main/scala/fpinscala/laziness/Stream.scala
@@ -3,6 +3,8 @@ package fpinscala.laziness
 import Stream._
 trait Stream[+A] {
 
+  def toList: List[A] = ???
+
   def foldRight[B](z: => B)(f: (A, => B) => B): B = // The arrow `=>` in front of the argument type `B` means that the function `f` takes its second argument by name and may choose not to evaluate it.
     this match {
       case Cons(h,t) => f(h(), t().foldRight(z)(f)) // If `f` doesn't evaluate its second argument, the recursion never occurs.


### PR DESCRIPTION
I figured for consistency with the other exercises, this function should be added to the Stream file as undefined? (The definition is given in the book)