### PR TITLE
Changed type ordering for `f` HOF

### DIFF
--- a/answerkey/datastructures/13.answer.scala
+++ b/answerkey/datastructures/13.answer.scala
@@ -4,7 +4,7 @@ The implementation of `foldRight` in terms of `reverse` and `foldLeft` is a comm
 The other implementations build up a chain of functions which, when called, results in the operations being performed with the correct associativity. We are calling `foldRight` with the `B` type being instantiated to `B => B`, then calling the built up function with the `z` argument. Try expanding the definitions by substituting equals for equals using a simple example, like `foldLeft(List(1,2,3), 0)(_ + _)` if this isn't clear. Note these implementations are more of theoretical interest - they aren't stack-safe and won't work for large lists.
 */
 def foldRightViaFoldLeft[A,B](l: List[A], z: B)(f: (A,B) => B): B = 
-  foldLeft(reverse(l), z)((b,a) => f(a,b))
+  foldLeft(reverse(l), z)((a,b) => f(a,b))
 
 def foldRightViaFoldLeft_1[A,B](l: List[A], z: B)(f: (A,B) => B): B = 
   foldLeft(l, (b:B) => b)((g,a) => b => g(f(a,b)))(z)


### PR DESCRIPTION
in `foldRightViaFoldLeft` function.

I've implemented my "version" of this exercise and then came here to check for answer's validation.

I tried to use as described, but it failed with message:

```
[error] /Users/hlegius/OneDrive/coding/scala-experiments/books-bakedcodes/fp-in-scala/src/main/scala/fpinscala/chapter3/Lists.scala:57:45: type mismatch;
[error]  found   : a.type (with underlying type B)
[error]  required: A
[error]     foldLeft(reverseLeft(as), z)((b,a) => f(a, b))
[error]                                             ^
[error] /Users/hlegius/OneDrive/coding/scala-experiments/books-bakedcodes/fp-in-scala/src/main/scala/fpinscala/chapter3/Lists.scala:57:48: type mismatch;
[error]  found   : b.type (with underlying type A)
[error]  required: B
[error]     foldLeft(reverseLeft(as), z)((b,a) => f(a, b))
[error]                                                ^
[error] two errors found
```

Changing to follow-the-types, it worked properly. Here is my scala spec snippet:

```scala
"foldRightLeft" should "behaves like foldRight function" in {
  val list = List(1, 2, 3, 4)

  foldRightLeft(list, Seq.empty[Int])((e, xs) => e +: xs) shouldEqual list                                                                                                                          
}
```

And it worked like expected.