### PR TITLE
Exercise 15.2, implement count with tail-recursive function

### DIFF
--- a/answerkey/streamingio/02.answer.scala
+++ b/answerkey/streamingio/02.answer.scala
@@ -14,8 +14,10 @@ def count[I]: Process[I,Int] =
 
 /* For comparison, here is an explicit recursive implementation. */
 def count2[I]: Process[I,Int] = {
-  def go(n: Int): Process[I,Int] =
-    await((i: I) => emit(n+1, go(n+1)))
+  def go(n: Int): Process[I,Int] = Await {
+    case Some(_) => go(n+1)
+    case None => emit(n)
+  }
   go(0)
 }
 

--- a/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
@@ -344,8 +344,10 @@ object SimpleStreamTransducers {
 
     /* For comparison, here is an explicit recursive implementation. */
     def count2[I]: Process[I,Int] = {
-      def go(n: Int): Process[I,Int] =
-        await((i: I) => emit(n+1, go(n+1)))
+      def go(n: Int): Process[I,Int] = Await {
+        case Some(_) => go(n+1)
+        case None => emit(n)
+      }
       go(0)
     }
 


### PR DESCRIPTION
If we don't use the `await` helper function and implement `go` in terms of the `Await` data constructor then it becomes tail-recursive.

Is there a point in emitting a running count as in the original solution?