### PR TITLE
Fix bug in answerkey/streamingio: takeThrough

### DIFF
--- a/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
+++ b/answers/src/main/scala/fpinscala/streamingio/StreamingIO.scala
@@ -434,8 +434,9 @@ object SimpleStreamTransducers {
      * Like `takeWhile`, but includes the first element that tests
      * false.
      */
-    def takeThrough[I](f: I => Boolean): Process[I,I] =
-      takeWhile(f) ++ echo
+     def takeThrough[I](f: I => Boolean): Process[I, I] = await(i =>
+       if (f(i)) emit(i, takeThrough(f))
+       else      emit(i))
 
     /* Awaits then emits a single value, then halts. */
     def echo[I]: Process[I,I] = await(i => emit(i))


### PR DESCRIPTION
Chapter 15, Streaming IO. `existsResult` and `takeThrough` does not behave as expected:

```
$ sbt ';project answers; console'
[info] Loading global plugins from /Users/jgogstad/.sbt/0.13/plugins
[info] Loading project definition from /Users/jgogstad/development/jgogstad/fpinscala/project
[info] Set current project to fpinscala (in build file:/Users/jgogstad/development/jgogstad/fpinscala/)
[info] Set current project to answers (in build file:/Users/jgogstad/development/jgogstad/fpinscala/)
[info] Starting scala interpreter...
[info]
Welcome to Scala 2.12.1 (Java HotSpot(TM) 64-Bit Server VM, Java 1.8.0_162).
Type in expressions for evaluation. Or try :help.

scala> import fpinscala.streamingio.SimpleStreamTransducers.Process._
import fpinscala.streamingio.SimpleStreamTransducers.Process._

scala> existsResult[Boolean](_ == true)(Stream(true)).toList
res0: List[Boolean] = List(false)

scala> takeThrough[Boolean](_ == true)(Stream(true, false)).toList
res1: List[Boolean] = List(true)

scala>
```

It's because `takeWhile` consumes the last element, `echo` never sees it.

By explicitly emitting in `takeThrough` we get the expected behavior:

```
scala> takeThrough[Boolean](_ == true)(Stream(true, false)).toList
res0: List[Boolean] = List(true, false)

scala> existsResult[Boolean](_ == true)(Stream(true)).toList
res1: List[Boolean] = List(true)
```