### PR TITLE
fix(freeMonad): solution for excercise 13.2 and 13.3

### DIFF
--- a/answerkey/iomonad/02.answer.scala
+++ b/answerkey/iomonad/02.answer.scala
@@ -1,10 +1,10 @@
   @annotation.tailrec
   def runTrampoline[A](a: Free[Function0,A]): A = (a) match {
     case Return(a) => a
-    case Suspend(r) => r()
+    case Suspend(r) => runTrampoline(r())
     case FlatMap(x,f) => x match {
       case Return(a) => runTrampoline { f(a) }
-      case Suspend(r) => runTrampoline { f(r()) }
+      case Suspend(r) => runTrampoline { r() flatMap f }
       case FlatMap(a0,g) => runTrampoline { a0 flatMap { a0 => g(a0) flatMap f } }
     }
   }

--- a/answerkey/iomonad/03.answer.scala
+++ b/answerkey/iomonad/03.answer.scala
@@ -1,7 +1,15 @@
   // Exercise 3: Implement a `Free` interpreter which works for any `Monad`
   def run[F[_],A](a: Free[F,A])(implicit F: Monad[F]): F[A] = step(a) match {
     case Return(a) => F.unit(a)
-    case Suspend(r) => r
-    case FlatMap(Suspend(r), f) => F.flatMap(r)(a => run(f(a)))
+    case Suspend(r) => F.flatMap(r)(a => run(a))
+    case FlatMap(Suspend(r), f) => F.flatMap(r)(a0 => run(a0.flatMap(f))
     case _ => sys.error("Impossible, since `step` eliminates these cases")
+  }
+
+  def step[A](a: Free[F, A]): Free[F, A] = {
+    a match {
+      case FlatMap(Return(a), f) => step(f(a))
+      case FlatMap(FlatMap(a, g), f) => step(a.flatMap(a0 => g(a0) flatMap f))
+      case _ => a
+    }
   }


### PR DESCRIPTION
The provided solution for exercises 13.2 and 13.3 were incorrect, this PR attempts to fix them.

`Suspend` should be defined as-

`case class Suspend[F[_],A](f: F[Free[F, A]]) extends Free[F,A]` 

but in the book snippet it says

`case class Suspend[F[_],A](f: F[ A]) extends Free[F,A]`

the correct [definition](https://github.com/fpinscala/fpinscala/wiki/Chapter-13:-External-effects-and-IO) changes the solution.