### PR TITLE
Fix startsWith in laziness answers

### DIFF
--- a/answers/src/main/scala/fpinscala/laziness/Stream.scala
+++ b/answers/src/main/scala/fpinscala/laziness/Stream.scala
@@ -155,8 +155,8 @@ trait Stream[+A] {
   /*
   `s startsWith s2` when corresponding elements of `s` and `s2` are all equal, until the point that `s2` is exhausted. If `s` is exhausted first, or we find an element that doesn't match, we terminate early. Using non-strictness, we can compose these three separate logical steps--the zipping, the termination when the second stream is exhausted, and the termination if a nonmatching element is found or the first stream is exhausted.
   */
-  def startsWith[A](s: Stream[A]): Boolean =
-    zipAll(s).takeWhile(!_._2.isEmpty) forAll {
+  def startsWith[B](s: Stream[B]): Boolean =
+    (this zipAll s).takeWhile(_._2.isDefinded) forAll {
       case (h,h2) => h == h2
     }
 


### PR DESCRIPTION
1. Change function type like in the corresponding exercise
2. Improve readability by changing !_._2.isEmpty to _._2.isDefined