### PR TITLE
Enable users of Java 11 and Metals

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 tags
 target
 project/boot
+project/metals.sbt
 .history
 project.vim
 *.old
@@ -10,3 +11,5 @@ project.vim
 .project
 .classpath
 .metadata/
+.bloop/
+.metals/

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: scala
 sudo: false
 scala:
-  - 2.11.5
+  - 2.12.11
 jdk:
-  - oraclejdk7
-  - openjdk7
+  - oraclejdk11
+  - openjdk11
 notifications:
   email: false

--- a/answers/src/main/scala/fpinscala/parsing/Parsers.scala
+++ b/answers/src/main/scala/fpinscala/parsing/Parsers.scala
@@ -188,7 +188,7 @@ case class Location(input: String, offset: Int = 0) {
 
   /* Returns the line corresponding to this location */
   def currentLine: String =
-    if (input.length > 1) input.lines.drop(line-1).next
+    if (input.length > 1) input.linesIterator.drop(line-1).next
     else ""
 
   def columnCaret = (" " * (col-1)) + "^"

--- a/build.sbt
+++ b/build.sbt
@@ -1,5 +1,5 @@
 val commonSettings = Seq(
-  scalaVersion := "2.12.1"
+  scalaVersion := "2.12.11"
 )
 
 lazy val root = (project in file("."))

--- a/exercises/src/main/scala/fpinscala/parsing/Parsers.scala
+++ b/exercises/src/main/scala/fpinscala/parsing/Parsers.scala
@@ -25,7 +25,7 @@ case class Location(input: String, offset: Int = 0) {
 
   /* Returns the line corresponding to this location */
   def currentLine: String = 
-    if (input.length > 1) input.lines.drop(line-1).next
+    if (input.length > 1) input.linesIterator.drop(line-1).next
     else ""
 }
 

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.13
+sbt.version=1.2.8


### PR DESCRIPTION
As detailed in the commit messages, this PR:

- satisfies the minimum requirements to use [Metals](https://scalameta.org/metals/)
- replaces calls to `String#lines` with `String#linesIterator` to make sure the provided code compiles when using the Java 11 standard library