### PR TITLE
Add unfold-based implementation for `scanRight`

### DIFF
--- a/answerkey/laziness/16.answer.scala
+++ b/answerkey/laziness/16.answer.scala
@@ -1,7 +1,5 @@
 /*
-The function can't be implemented using `unfold`, since `unfold` generates elements of the `Stream` from left to right. It can be implemented using `foldRight` though.
-
-The implementation is just a `foldRight` that keeps the accumulated value and the stream of intermediate results, which we `cons` onto during each iteration. When writing folds, it's common to have more state in the fold than is needed to compute the result. Here, we simply extract the accumulated list once finished.
+This implementation is just a `foldRight` that keeps the accumulated value and the stream of intermediate results, which we `cons` onto during each iteration. When writing folds, it's common to have more state in the fold than is needed to compute the result. Here, we simply extract the accumulated list once finished.
 */
   def scanRight[B](z: B)(f: (A, => B) => B): Stream[B] =
     foldRight((z, Stream(z)))((a, p0) => {
@@ -10,3 +8,10 @@ The implementation is just a `foldRight` that keeps the accumulated value and th
       val b2 = f(a, p1._1)
       (b2, cons(b2, p1._2))
     })._2
+
+
+// Implementation via Stream.unfold, which performs more values evaluations.
+  def scanRightViaUnfold[R](e: => R)(c: (=> E, => R) => R): Stream[R] = Stream.unfold(this) {
+    case Empty => None
+    case s => Some((s.foldRight(e)(c), s.tail))
+  } append Stream(e)


### PR DESCRIPTION
Add unfold-based implementation for `scanRight` exercise in 'lazy evaluation' chapter

Passes this test:
```scala
assertResult(List(6, 5, 3, 0))(Stream(1, 2, 3).scanRight(0)(_ + _).toList)
```