### PR TITLE
Add lengthViaFoldLeft for Exercise 3.11

### DIFF
--- a/exercises/src/main/scala/fpinscala/datastructures/List.scala
+++ b/exercises/src/main/scala/fpinscala/datastructures/List.scala
@@ -64,6 +64,8 @@ object List: // `List` companion object. Contains functions for creating and wor
 
   def productViaFoldLeft(ns: List[Double]) = ???
 
+  def lengthViaFoldLeft[A](l: List[A]): Int = ???
+
   def reverse[A](l: List[A]): List[A] = ???
 
   def appendViaFoldRight[A](l: List[A], r: List[A]): List[A] = ???


### PR DESCRIPTION
There is a description in Exercise 3.11: "Write sum, product, and a function to compute the length of a list using foldLeft" but we have only two methods:

  def sumViaFoldLeft(ns: List[Int]) = ???

  def productViaFoldLeft(ns: List[Double]) = ???

I add the last one:

def lengthViaFoldLeft[A](l: List[A]) = ???