### PR TITLE
Fix def concat

### DIFF
--- a/exercises/src/main/scala/fpinscala/datastructures/List.scala
+++ b/exercises/src/main/scala/fpinscala/datastructures/List.scala
@@ -68,7 +68,7 @@ object List: // `List` companion object. Contains functions for creating and wor
 
   def appendViaFoldRight[A](l: List[A], r: List[A]): List[A] = ???
 
-  def concat[A](l: List[A], r: List[A]): List[A] = ???
+  def concat[A](l: List[List[A]]): List[A] = ???
 
   def incrementEach(l: List[Int]): List[Int] = ???
 


### PR DESCRIPTION
The correct signature of the concat method is 
def concat[A](l: List[List[A]]): List[A] = ???
instead of
def concat[A](l: List[A], r: List[A]): List[A] = ???