### PR TITLE
Add signatures for exercises 5.10 and 5.12

### DIFF
--- a/exercises/src/main/scala/fpinscala/laziness/LazyList.scala
+++ b/exercises/src/main/scala/fpinscala/laziness/LazyList.scala
@@ -53,5 +53,14 @@ object LazyList:
 
   def from(n: Int): LazyList[Int] = ???
 
+  val fibs: LazyList[Int] = ???
+
   def unfold[A, S](state: S)(f: S => Option[(A, S)]): LazyList[A] = ???
 
+  val fibsViaUnfold: LazyList[Int] = ???
+
+  def fromViaUnfold(n: Int): LazyList[Int] = ???
+
+  def continuallyViaUnfold[A](a: A): LazyList[A] = ???
+
+  val onesViaUnfold: LazyList[Int] = ???


### PR DESCRIPTION
We don't have a signature for Exercise 5.10:
`Write a function fibs that generates the infinite lazy list of Fibonacci numbers: 0, 1, 1, 2, 3, 5, 8, and so on.`

And for Exercise 5.12:
`Write fibs, from, continually, and ones in terms of unfold.`

These signatures are added in this PR.