### PR TITLE
Add NotImplementedError catching

### DIFF
--- a/src/main/scala/fpinscala/answers/testing/Exhaustive.scala
+++ b/src/main/scala/fpinscala/answers/testing/Exhaustive.scala
@@ -85,7 +85,7 @@ object Prop:
               if f(h) then go(i+1, j, t, onEnd)
               else Falsified(h.toString)
             catch
-              case e: Exception => Falsified(buildMsg(h, e))
+              case e: Throwable => Falsified(buildMsg(h, e))
           case None #:: _ => Passed(Unfalsified, i)
           case _ => onEnd(i)
       val numFromExhaustiveList = TestCases.fromInt(n.toInt / 3)
@@ -96,7 +96,7 @@ object Prop:
         case s => s // If proven or failed, stop immediately
     }
 
-  def buildMsg[A](s: A, e: Exception): String =
+  def buildMsg[A](s: A, e: Throwable): String =
     s"test case: $s\n" +
     s"generated an exception: ${e.getMessage}\n" +
     s"stack trace:\n ${e.getStackTrace.mkString("\n")}"

--- a/src/main/scala/fpinscala/answers/testing/Exhaustive.scala
+++ b/src/main/scala/fpinscala/answers/testing/Exhaustive.scala
@@ -1,6 +1,7 @@
 package fpinscala.answers.testing.exhaustive
 
 import annotation.targetName
+import scala.util.control.NonFatal
 
 /*
 This source file contains the answers to the last two exercises in the section
@@ -85,7 +86,7 @@ object Prop:
               if f(h) then go(i+1, j, t, onEnd)
               else Falsified(h.toString)
             catch
-              case e: Throwable => Falsified(buildMsg(h, e))
+              case NonFatal(e) => Falsified(buildMsg(h, e))
           case None #:: _ => Passed(Unfalsified, i)
           case _ => onEnd(i)
       val numFromExhaustiveList = TestCases.fromInt(n.toInt / 3)


### PR DESCRIPTION
We don't catch the most common Scala's error - `???` or `NotImplementedError` - in the case `case e: Exception`.
For example, when we first write the tests, and then - the implementation.

As a result we can see in the output:
```
Exception in thread "main" scala.NotImplementedError: an implementation is missing
	at scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
```

And we can't check all tests because we have an exception.

Maybe we can catch these situations too? 
Then we'll see the following in the output:
```
! Failed:
 MyProgram.fib(test case: 0
generated an exception: an implementation is missing
stack trace:
 scala.Predef$.$qmark$qmark$qmark(Predef.scala:344)
...
```