### PR TITLE
Add Exercise 6.9 templates

### DIFF
--- a/src/main/scala/fpinscala/exercises/state/State.scala
+++ b/src/main/scala/fpinscala/exercises/state/State.scala
@@ -45,6 +45,10 @@ object RNG:
 
   def flatMap[A, B](r: Rand[A])(f: A => Rand[B]): Rand[B] = ???
 
+  def mapViaFlatMap[A, B](r: Rand[A])(f: A => B): Rand[B] = ???
+
+  def map2ViaFlatMap[A, B, C](ra: Rand[A], rb: Rand[B])(f: (A, B) => C): Rand[C] = ???
+
 opaque type State[S, +A] = S => (A, S)
 
 object State:


### PR DESCRIPTION
We can add templates for Exercise 6.9 because we know `map` and `map2` signatures.

```
Exercise 6.9
Reimplement map and map2 in terms of flatMap...
```