### PR TITLE
Unit-tests for chapters 5 and 6

### DIFF
--- a/src/main/scala/fpinscala/exercises/laziness/LazyList.scala
+++ b/src/main/scala/fpinscala/exercises/laziness/LazyList.scala
@@ -53,14 +53,14 @@ object LazyList:
 
   def from(n: Int): LazyList[Int] = ???
 
-  val fibs: LazyList[Int] = ???
+  lazy val fibs: LazyList[Int] = ???
 
   def unfold[A, S](state: S)(f: S => Option[(A, S)]): LazyList[A] = ???
 
-  val fibsViaUnfold: LazyList[Int] = ???
+  lazy val fibsViaUnfold: LazyList[Int] = ???
 
   def fromViaUnfold(n: Int): LazyList[Int] = ???
 
   def continuallyViaUnfold[A](a: A): LazyList[A] = ???
 
-  val onesViaUnfold: LazyList[Int] = ???
+  lazy val onesViaUnfold: LazyList[Int] = ???

--- a/src/test/scala/fpinscala/exercises/common/Common.scala
+++ b/src/test/scala/fpinscala/exercises/common/Common.scala
@@ -1,0 +1,20 @@
+package fpinscala.exercises.common
+
+import fpinscala.answers.testing.exhaustive.Gen
+
+object Common:
+  val theFirst21FibonacciNumbers =
+    IndexedSeq(0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181, 6765)
+  val genLengthOfFibonacciSeq: Gen[Int] = Gen.choose(0, theFirst21FibonacciNumbers.length)
+  val genShortNumber: Gen[Int] = Gen.choose(0, 20)
+  val genChar: Gen[Char] = Gen.choose(97, 123).map(_.toChar)
+  val genString: Gen[String] = genList(genChar).map(_.mkString)
+  val genIntList: Gen[List[Int]] = genList(Gen.int)
+  val genDoubleList: Gen[List[Double]] = genList(Gen.double)
+  val genStringList: Gen[List[String]] = genList(genString)
+
+  def genList[A](g: Gen[A]): Gen[List[A]] =
+    for
+      n <- genShortNumber
+      list <- Gen.listOfN(n, g)
+    yield list

--- a/src/test/scala/fpinscala/exercises/common/PropSuite.scala
+++ b/src/test/scala/fpinscala/exercises/common/PropSuite.scala
@@ -1,4 +1,4 @@
-package fpinscala.exercises.munit
+package fpinscala.exercises.common
 
 import fpinscala.answers.state.RNG
 import fpinscala.answers.testing.exhaustive.*
@@ -19,7 +19,7 @@ trait PropSuite extends FunSuite:
         true
     val prop = forAll[A](a)(g)
     test(new TestOptions(name, Set.empty, loc))(prop.check())
-  
+
   override def munitTestTransforms: List[TestTransform] =
     super.munitTestTransforms :+ scalaCheckPropTransform
 
@@ -41,4 +41,4 @@ trait PropSuite extends FunSuite:
         println(s"${test.name}: + OK, property ${status.toString.toLowerCase}, ran $n tests.")
         Success(())
       case Falsified(msg) =>
-        Try(fail(msg.toString)(test.location))
+        Try(fail(msg.string)(test.location))

--- a/src/test/scala/fpinscala/exercises/datastructures/ListSuite.scala
+++ b/src/test/scala/fpinscala/exercises/datastructures/ListSuite.scala
@@ -2,29 +2,20 @@ package fpinscala.exercises.datastructures
 
 import fpinscala.answers.testing.exhaustive.*
 import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.Common.{genShortNumber, genDoubleList as genDoubleSList, genIntList as genIntSList}
+import fpinscala.exercises.common.PropSuite
 import fpinscala.exercises.datastructures.*
 import fpinscala.exercises.datastructures.List.*
-import fpinscala.exercises.munit.PropSuite
 
 import scala.util.Try
 import scala.{List as SList, Nil as SNil}
 
-class ListProps extends PropSuite:
-  private val genIntList: Gen[List[Int]] =
-    for {
-      length <- Gen.choose(0, 10)
-      slist <- Gen.listOfN(length, Gen.int)
-    } yield scalaListToList(slist)
-
-  private val genDoubleList: Gen[List[Double]] =
-    for {
-      length <- Gen.choose(0, 10)
-      slist <- Gen.listOfN(length, Gen.double)
-    } yield scalaListToList(slist)
-
+class ListSuite extends PropSuite:
+  private val genIntList: Gen[List[Int]] = genIntSList.map(scalaListToList)
+  private val genDoubleList: Gen[List[Double]] = genDoubleSList.map(scalaListToList)
   private val genListOfLists: Gen[List[List[Int]]] =
     for {
-      length <- Gen.choose(0, 10)
+      length <- genShortNumber
       slist <- Gen.listOfN(length, genIntList)
     } yield scalaListToList(slist)
 

--- a/src/test/scala/fpinscala/exercises/datastructures/TreeSuite.scala
+++ b/src/test/scala/fpinscala/exercises/datastructures/TreeSuite.scala
@@ -2,13 +2,14 @@ package fpinscala.exercises.datastructures
 
 import fpinscala.answers.testing.exhaustive.*
 import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.Common.*
+import fpinscala.exercises.common.PropSuite
 import fpinscala.exercises.datastructures.Tree
 import fpinscala.exercises.datastructures.Tree.*
-import fpinscala.exercises.munit.PropSuite
 
 import scala.List as SList
 
-class TreeProps extends PropSuite:
+class TreeSuite extends PropSuite:
   private val genIntTree: Gen[Tree[Int]] =
     def loop(): Gen[Tree[Int]] =
       Gen.boolean.flatMap {

--- a/src/test/scala/fpinscala/exercises/errorhandling/EitherSuite.scala
+++ b/src/test/scala/fpinscala/exercises/errorhandling/EitherSuite.scala
@@ -2,20 +2,12 @@ package fpinscala.exercises.errorhandling
 
 import fpinscala.answers.testing.exhaustive.*
 import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.Common.*
+import fpinscala.exercises.common.PropSuite
 import fpinscala.exercises.errorhandling.*
 import fpinscala.exercises.errorhandling.Either.*
-import fpinscala.exercises.munit.PropSuite
 
-class EitherProps extends PropSuite:
-  private val genChar: Gen[Char] =
-    Gen.choose(97, 123).map(_.toChar)
-
-  private val genString: Gen[String] =
-    for {
-      n <- Gen.choose(0, 20)
-      list <- Gen.listOfN(n, genChar)
-    } yield list.mkString
-
+class EitherSuite extends PropSuite:
   private val genEither: Gen[Either[String, Int]] =
     Gen.union(genString.map(Left(_)), Gen.int.map(Right(_)))
 

--- a/src/test/scala/fpinscala/exercises/errorhandling/OptionSuite.scala
+++ b/src/test/scala/fpinscala/exercises/errorhandling/OptionSuite.scala
@@ -2,55 +2,44 @@ package fpinscala.exercises.errorhandling
 
 import fpinscala.answers.testing.exhaustive.*
 import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.Common.*
+import fpinscala.exercises.common.PropSuite
 import fpinscala.exercises.errorhandling.*
 import fpinscala.exercises.errorhandling.Option.*
-import fpinscala.exercises.munit.PropSuite
 
 import scala.{Either as SEither, Left as SLeft, None as SNone, Option as SOption, Right as SRight, Some as SSome}
 
-class OptionProps extends PropSuite:
+class OptionSuite extends PropSuite:
   private val genIntOption: Gen[Option[Int]] =
     Gen.union(Gen.unit(None), Gen.int.map(Some(_)))
 
-  private val genDoubleList: Gen[List[Double]] =
-    Gen.choose(0, 10).flatMap(n => Gen.listOfN(n, Gen.double))
-
-  private val genNoneSeq: Gen[List[Option[Int]]] = Gen.unit(List(None))
+  private val genNoneSeq: Gen[List[Option[Int]]] =
+    Gen.unit(List(None))
 
   private val genListWithNone: Gen[List[Option[Int]]] =
-    for {
-      length <- Gen.choose(0, 10)
-      genListWithNone <- Gen.listOfN[Option[Int]](length, genIntOption)
-    } yield genListWithNone
+    genList(genIntOption)
 
   private val genListWithoutNone: Gen[List[Option[Int]]] =
-    for {
-      length <- Gen.choose(0, 10)
-      genList <- Gen.listOfN[Option[Int]](length, Gen.int.map(Some(_)))
-    } yield genList
+    genList(Gen.int.map(Some(_)))
 
   private val genOptionSeq: Gen[List[Option[Int]]] =
     Gen.union(genNoneSeq, Gen.union(genListWithNone, genListWithoutNone))
 
   private val genListWithRandomString: Gen[List[String]] =
-    Gen.choose(0, 10).flatMap { n =>
-      Gen.listOfN(n, Gen.union(Gen.unit("one"), Gen.int.map(_.toString)))
-    }
+    genList(Gen.union(Gen.unit("one"), Gen.int.map(_.toString)))
 
   private val genListWithValidNumbers: Gen[List[String]] =
-    Gen.choose(0, 10).flatMap(n => Gen.listOfN(n, Gen.int.map(_.toString)))
+    genList(Gen.int.map(_.toString))
 
   private val genStringList: Gen[List[String]] =
-    Gen.union(
-      genListWithRandomString,
-      genListWithValidNumbers
-    )
+    Gen.union(genListWithRandomString, genListWithValidNumbers)
 
   private val intToString: Int => String = a => a.toString
   private val intToOptString: Int => Option[String] = a => Some(a.toString)
-  private val strToOptInt: String => Option[Int] = _.toIntOption match
-    case SNone        => None
-    case SSome(value) => Some(value)
+  private val strToOptInt: String => Option[Int] =
+    _.toIntOption match
+      case SNone        => None
+      case SSome(value) => Some(value)
 
   private val otherOpt: Option[Int] = Some(1)
 

--- a/src/test/scala/fpinscala/exercises/gettingstarted/GettingStartedSuite.scala
+++ b/src/test/scala/fpinscala/exercises/gettingstarted/GettingStartedSuite.scala
@@ -2,25 +2,18 @@ package fpinscala.exercises.gettingstarted
 
 import fpinscala.answers.testing.exhaustive.*
 import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.Common.*
+import fpinscala.exercises.common.PropSuite
 import fpinscala.exercises.gettingstarted.MyProgram.fib
 import fpinscala.exercises.gettingstarted.PolymorphicFunctions.{compose, curry, isSorted, uncurry}
-import fpinscala.exercises.munit.PropSuite
 
 class GettingStartedSuite extends PropSuite:
-  private val theFirst21FibonacciNumbers =
-    IndexedSeq(0, 1, 1, 2, 3, 5, 8, 13, 21, 34, 55, 89, 144, 233, 377, 610, 987, 1597, 2584, 4181, 6765)
-
   private lazy val mulCurry: Int => Int => Int = curry[Int, Int, Int]((a: Int, b: Int) => a * b)
 
   private lazy val mulUncurry: (Int, Int) => Int = uncurry[Int, Int, Int]((a: Int) => (b: Int) => a * b)
 
-  private val genShortNumber = Gen.choose(0, 20)
-
   private val genSortedArray: Gen[Array[Int]] =
-    for {
-      n <- genShortNumber
-      list <- Gen.listOfN(n, genShortNumber)
-    } yield list.sorted.toArray
+    genList(genShortNumber).map(_.sorted.toArray)
 
   private val genUnsortedArray: Gen[Array[Int]] =
     for {
@@ -31,7 +24,7 @@ class GettingStartedSuite extends PropSuite:
       else num - 100
     }.toArray
 
-  test("MyProgram.fib")(genShortNumber) { i =>
+  test("MyProgram.fib")(genLengthOfFibonacciSeq) { i =>
     assertEquals(fib(i), theFirst21FibonacciNumbers(i))
   }
 

--- a/src/test/scala/fpinscala/exercises/laziness/LazyListSuite.scala
+++ b/src/test/scala/fpinscala/exercises/laziness/LazyListSuite.scala
@@ -1,0 +1,165 @@
+package fpinscala.exercises.laziness
+
+import fpinscala.answers.testing.exhaustive.*
+import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.Common.*
+import fpinscala.exercises.common.PropSuite
+import fpinscala.exercises.laziness.LazyList
+import fpinscala.exercises.laziness.LazyList.*
+
+import scala.util.{Random, Try}
+
+class LazyListSuite extends PropSuite:
+  private val genSmallInt = Gen.choose(0, 10)
+  private val genMidInt = Gen.choose(0, 100)
+
+  private lazy val genLazyList: Gen[LazyList[Int]] =
+    def loop(): Gen[LazyList[Int]] =
+      Gen.boolean.flatMap { b =>
+        if b then Gen.unit(Empty)
+        else
+          for {
+            head <- Gen.int
+            tail <- loop()
+          } yield Cons(() => head, () => tail)
+      }
+    loop()
+
+  test("LazyList.headOption")(genLazyList) {
+    case Empty      => assert(Empty.headOption.isEmpty)
+    case Cons(h, t) => assert(Cons(h, t).headOption.contains(h()))
+  }
+
+  test("LazyList.cons") {
+    genLazyList.map(tail => (LazyList.cons(Random.nextInt, tail), Cons(Random.nextInt, () => tail)))
+  } { (smartConstructor, oldConstructor) =>
+    assertEquals(smartConstructor.headOption, smartConstructor.headOption)
+    assertNotEquals(oldConstructor.headOption, oldConstructor.headOption)
+  }
+
+  test("LazyList.toList")(genIntList) { list =>
+    assertEquals(LazyList(list*).toList, list)
+  }
+
+  test("LazyList.take")(genSmallInt ** genLazyList) { case (n, lazyList) =>
+    assertEquals(lazyList.take(n).toList, lazyList.toList.take(n))
+  }
+
+  test("LazyList.drop")(genSmallInt ** genLazyList) { case (n, lazyList) =>
+    assertEquals(lazyList.drop(n).toList, lazyList.toList.drop(n))
+  }
+
+  test("LazyList.takeWhile")(genSmallInt ** genLazyList) { case (n, lazyList) =>
+    assertEquals(lazyList.takeWhile(_ != n).toList, lazyList.toList.takeWhile(_ != n))
+  }
+
+  test("LazyList.forAll")(genSmallInt ** genLazyList) { case (n, lazyList) =>
+    assertEquals(lazyList.forAll(_ != n), !lazyList.toList.contains(n))
+  }
+
+  /*
+  test("LazyList.map")(genSmallInt ** genLazyList) { case (n, lazyList) =>
+    assertEquals(lazyList.map(_ + n).toList, lazyList.toList.map(_ + n))
+  }
+
+  test("LazyList.filter")(genSmallInt ** genLazyList) { case (n, lazyList) =>
+    assertEquals(lazyList.filter(_ != n).toList, lazyList.toList.filter(_ != n))
+  }
+
+  test("LazyList.append")(genLazyList ** genLazyList) { case (first, second) =>
+    assertEquals(first.append(second).toList, first.toList ++ second.toList)
+  }
+
+  test("LazyList.flatMap")(genSmallInt ** genLazyList) { case (n, lazyList) =>
+    assertEquals(lazyList.flatMap(a => LazyList(a + n)).toList, lazyList.toList.flatMap(a => List(a + n)))
+  }
+   */
+
+  test("LazyList.ones")(genMidInt) { n =>
+    assertEquals(ones.take(n).toList, List.fill(n)(1))
+  }
+
+  test("LazyList.continually")(genMidInt ** genMidInt) { (n, a) =>
+    assertEquals(continually(a).take(n).toList, List.fill(n)(a))
+  }
+
+  test("LazyList.from")(genMidInt ** genMidInt) { (n, a) =>
+    assertEquals(from(a).take(n).toList, (a until (a + n)).toList)
+  }
+
+  test("LazyList.fib")(genLengthOfFibonacciSeq) { n =>
+    assertEquals(fibs.take(n).toList, theFirst21FibonacciNumbers.take(n).toList)
+  }
+
+  test("LazyList.unfold")(genMidInt) { n =>
+    val genFirstNumbers: Int => Option[(Int, Int)] =
+      m => if m > n then None else Some((m, m + 1))
+    assertEquals(unfold(1)(genFirstNumbers).toList, (1 to n).toList)
+  }
+
+  test("LazyList.fibsViaUnfold")(genLengthOfFibonacciSeq) { n =>
+    assertEquals(fibsViaUnfold.take(n).toList, theFirst21FibonacciNumbers.take(n).toList)
+  }
+
+  test("LazyList.fromViaUnfold")(genMidInt ** genMidInt) { (n, a) =>
+    assertEquals(fromViaUnfold(a).take(n).toList, (a until (a + n)).toList)
+  }
+
+  test("LazyList.continuallyViaUnfold")(genMidInt ** genMidInt) { (n, a) =>
+    assertEquals(continuallyViaUnfold(a).take(n).toList, List.fill(n)(a))
+  }
+
+  test("LazyList.onesViaUnfold")(genMidInt) { n =>
+    assertEquals(onesViaUnfold.take(n).toList, List.fill(n)(1))
+  }
+
+  /*
+  test("LazyList.mapViaUnfold")(genSmallInt ** genLazyList) { case (n, lazyList) =>
+    assertEquals(lazyList.mapViaUnfold(_ + n).toList, lazyList.toList.map(_ + n))
+  }
+
+  test("LazyList.takeViaUnfold")(genSmallInt ** genLazyList) { case (n, lazyList) =>
+    assertEquals(lazyList.takeViaUnfold(n).toList, lazyList.toList.take(n))
+  }
+
+  test("LazyList.takeWhileViaUnfold")(genSmallInt ** genLazyList) { case (n, lazyList) =>
+    assertEquals(lazyList.takeWhileViaUnfold(_ != n).toList, lazyList.toList.takeWhile(_ != n))
+  }
+
+  test("LazyList.zipWith")(genLazyList ** genLazyList) { case (first, second) =>
+    assertEquals(first.zipWith(second)(_ + _).toList, first.toList.zip(second.toList).map(_ + _))
+  }
+
+  test("LazyList.zipAll")(genLazyList ** genLazyList) { case (first, second) =>
+    assertEquals(first.zipAll(second).toList, first.toList.map(Some(_)).zipAll(second.toList.map(Some(_)), None, None))
+  }
+   */
+
+  test("LazyList.startsWith")(genLazyList ** genLazyList) { case (list1, list2) =>
+    assertEquals(list1.startsWith(list2), list1.toList.startsWith(list2.toList))
+    assert(list1.startsWith(empty))
+    assert(list1.startsWith(list1))
+  }
+
+/*
+  test("LazyList.tails")(genLazyList) { lazyList =>
+    val list = lazyList.toList
+    val expected = (0 to list.length).map(i => list.drop(i)).toList
+    assertEquals(lazyList.tails.toList.map(_.toList), expected)
+  }
+
+  test("LazyList.hasSubsequence")(genSmallInt ** genLazyList) { case (n, list) =>
+    assert(list.hasSubsequence(Empty))
+    assert(list.hasSubsequence(list))
+    assert(list.hasSubsequence(list.drop(n)))
+  }
+
+  test("LazyList.hasSubsequence - random lazy lists")(genLazyList ** genLazyList) { (list1, list2) =>
+    assertEquals(list1.hasSubsequence(list2), list1.toList.containsSlice(list2.toList))
+  }
+
+  test("LazyList.scanRight")(genLazyList) { lazyList =>
+    assertEquals(lazyList.scanRight(0)(_ + _).toList, lazyList.tails.map(_.toList.sum).toList)
+    assertEquals(lazyList.scanRight(1)(_ * _).toList, lazyList.tails.map(_.toList.product).toList)
+  }
+ */

--- a/src/test/scala/fpinscala/exercises/state/CandySuite.scala
+++ b/src/test/scala/fpinscala/exercises/state/CandySuite.scala
@@ -1,0 +1,96 @@
+package fpinscala.exercises.state
+
+import fpinscala.answers.testing.exhaustive.*
+import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.Common.*
+import fpinscala.exercises.common.PropSuite
+import fpinscala.exercises.state.Candy.*
+import fpinscala.exercises.state.Input.*
+import fpinscala.exercises.state.State.*
+import fpinscala.exercises.state.{ Input, Machine, State }
+
+class CandySuite extends PropSuite:
+  private val genPosInt: Gen[Int]    = Gen.choose(1, 1000)
+  private val genNonNegInt: Gen[Int] = Gen.choose(0, 1000)
+  private val genInput: Gen[Input] =
+    Gen.boolean.map(b => if b then Coin else Turn)
+  private val genInputList: Gen[List[Input]] =
+    genList(genInput)
+
+  private val genNoCandiesMachine: Gen[Machine] =
+    for
+      locked <- Gen.boolean
+      coins  <- genNonNegInt
+    yield Machine(locked, 0, coins)
+
+  private val genLockedMachine: Gen[Machine] =
+    for
+      candies <- genPosInt // A machine must have at least one candy
+      coins <- genNonNegInt
+    yield Machine(true, candies, coins)
+
+  private val genUnlockedMachine: Gen[Machine] =
+    for
+      candies <- genPosInt // A machine must have at least one candy
+      coins <- genNonNegInt
+    yield Machine(false, candies, coins)
+
+  private val genMachine: Gen[Machine] =
+    for
+      locked  <- Gen.boolean
+      candies <- genNonNegInt
+      coins   <- genNonNegInt
+    yield Machine(locked, candies, coins)
+
+  test("Candy: a machine that’s out of candy")(genInputList ** genNoCandiesMachine) { (inputs, machine) =>
+    val ((coins, candies), machine1): ((Int, Int), Machine) = simulateMachine(inputs).run(machine)
+    assertEquals(candies, 0)
+    assertEquals(coins, machine.coins)
+    assertEquals(machine1, machine) // A machine that’s out of candy ignores all inputs.
+  }
+
+  test("Candy: inserting a coin into a locked machine")(genLockedMachine) { machine =>
+    val ((coins, candies), machine1): ((Int, Int), Machine) = simulateMachine(List(Coin)).run(machine)
+    assertEquals(candies, machine.candies)
+    assertEquals(coins, machine.coins + 1)                 // One more coin
+    assertEquals(machine1, Machine(false, candies, coins)) // Unlock a machine
+  }
+
+  test("Candy: turning the knob on a locked machine")(genLockedMachine) { machine =>
+    val ((coins, candies), machine1): ((Int, Int), Machine) = simulateMachine(List(Turn)).run(machine)
+    assertEquals(candies, machine.candies)
+    assertEquals(coins, machine.coins)
+    assertEquals(machine1, machine) // Nothing changed
+  }
+
+  test("Candy: inserting a coin into an unlocked machine")(genUnlockedMachine) { machine =>
+    val ((coins, candies), machine1): ((Int, Int), Machine) = simulateMachine(List(Coin)).run(machine)
+    assertEquals(candies, machine.candies)
+    assertEquals(coins, machine.coins)
+    assertEquals(machine1, machine) // Nothing changed
+  }
+
+  test("Candy: turning the knob on an unlocked machine")(genUnlockedMachine) { machine =>
+    val ((coins, candies), machine1): ((Int, Int), Machine) = simulateMachine(List(Turn)).run(machine)
+    assertEquals(candies, machine.candies - 1) // The buyer has taken the candy
+    assertEquals(coins, machine.coins)
+    assertEquals(machine1, Machine(true, candies, coins)) // Lock a machine
+  }
+
+  test("Candy: spend some coins")(genLockedMachine ** genPosInt) { (machine, myCoins) =>
+    val wantToSpendAllMyCoins = (0 until myCoins).flatMap(_ => List(Coin, Turn)).toList
+    val ((coins, candies), machine1): ((Int, Int), Machine) =
+      simulateMachine(wantToSpendAllMyCoins).run(machine)
+    val spentCoins = math.min(machine.candies, myCoins)
+
+    assertEquals(candies, machine.candies - spentCoins)
+    assertEquals(coins, machine.coins + spentCoins)
+    assertEquals(machine1, Machine(true, candies, coins))
+  }
+
+  test("Candy: empty inputs")(genMachine) { machine =>
+    val ((coins, candies), machine1): ((Int, Int), Machine) = simulateMachine(List.empty[Input]).run(machine)
+    assertEquals(candies, machine.candies)
+    assertEquals(coins, machine.coins)
+    assertEquals(machine1, machine) // Nothing changed
+  }

--- a/src/test/scala/fpinscala/exercises/state/RNGSuite.scala
+++ b/src/test/scala/fpinscala/exercises/state/RNGSuite.scala
@@ -1,0 +1,138 @@
+package fpinscala.exercises.state
+
+import fpinscala.answers.testing.exhaustive.*
+import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.PropSuite
+import fpinscala.exercises.state.RNG
+import fpinscala.exercises.state.RNG.*
+
+import scala.annotation.tailrec
+
+class RNGSuite extends PropSuite:
+  private val genRNG = Gen.int.map(Simple(_))
+  private val genCounter = Gen.choose(10, 100)
+  private val genLengthOfList = Gen.choose(-5, 20)
+  private val genSmallPosNum = Gen.choose(1, 1000)
+  private val isInInterval: Double => Boolean = d => 0 <= d && d < 1
+
+  test("RNG.nextInt")(genRNG) { rng =>
+    val (n1, rng2) = rng.nextInt
+    val (n2, rng3) = rng2.nextInt
+    val (n3, _) = rng3.nextInt
+    val (n4, _) = rng.nextInt
+    val (n5, _) = rng2.nextInt
+    assertNotEquals(n1, n2)
+    assertNotEquals(n1, n3)
+    assertEquals(n1, n4)
+    assertNotEquals(n2, n3)
+    assertEquals(n2, n5)
+  }
+
+  // Check that the first n-th numbers of the rng aren't a negative number?
+  test("RNG.nonNegativeInt")(genRNG ** genCounter) { case (rng, counter) =>
+    assert(checkRND(rng, counter, nonNegativeInt, _ >= 0))
+  }
+
+  // Check that the first n-th numbers of the rng are in the interval [0, 1)
+  test("RNG.double")(genRNG ** genCounter) { case (rng, counter) =>
+    assert(checkRND(rng, counter, double, isInInterval))
+  }
+
+  test("RNG.intDouble")(genRNG ** genCounter) { case (rng, counter) =>
+    assert(checkRND(rng, counter, intDouble, (_, d) => isInInterval(d)))
+  }
+
+  test("RNG.doubleInt")(genRNG ** genCounter) { case (rng, counter) =>
+    assert(checkRND(rng, counter, doubleInt, (d, _) => isInInterval(d)))
+  }
+
+  test("RNG.double3")(genRNG ** genCounter) { case (rng, counter) =>
+    val isCorrect: ((Double, Double, Double)) => Boolean =
+      (d1, d2, d3) => isInInterval(d1) && isInInterval(d2) && isInInterval(d3) && d1 != d2 && d1 != d3 && d2 != d3
+    assert(checkRND(rng, counter, double3, isCorrect))
+  }
+
+  test("RNG.ints")(genRNG ** genCounter ** genLengthOfList) { case ((rng, counter), lengthOfList) =>
+    if lengthOfList <= 0 then assert(ints(lengthOfList)(rng)._1.isEmpty)
+    else assert(checkRND(rng, counter, ints(lengthOfList), list => list == list.distinct))
+  }
+
+  test("RNG.int")(genRNG ** genCounter) { case (rng, counter) =>
+    assert(checkRND(rng, counter, int, _ => true))
+  }
+
+  test("RNG.unit")(genRNG ** genCounter) { case (rng, counter) =>
+    assert(checkRNGUnit(rng, counter, "unit"))
+    assert(checkRNGUnit(rng, counter, 0))
+    assert(checkRNGUnit(rng, counter, 0.0))
+  }
+
+  test("RNG.map")(genRNG ** genCounter) { case (rng, counter) =>
+    assert(checkRND(rng, counter, map(int)(_.toString), _.toIntOption.isDefined))
+  }
+
+  /*
+  test("RNG._double")(genRNG ** genCounter) { case (rng, counter) =>
+    assert(checkRND(rng, counter, _double, isInInterval))
+  }
+   */
+
+  test("RNG.map2")(genRNG ** genCounter) { case (rng, counter) =>
+    val randC = map2(double, double)((d1, d2) => (d1, d2))
+    assert(checkRND(rng, counter, randC, (d1, d2) => isInInterval(d1) && isInInterval(d2) && d1 != d2))
+  }
+
+  test("RNG.sequence")(genRNG ** genCounter ** genLengthOfList) { case ((rng, counter), lengthOfList) =>
+    val ints: Rand[List[Int]] = sequence(List.fill(lengthOfList)(int))
+    if lengthOfList <= 0 then assert(ints(rng)._1.isEmpty)
+    else assert(checkRND(rng, counter, ints, list => list == list.distinct))
+  }
+
+  test("RNG.flatMap")(genRNG ** genCounter ** genSmallPosNum) { case ((rng, counter), limit) =>
+    def nonNegativeLessThan(n: Int): Rand[Int] =
+      flatMap(nonNegativeInt) { i =>
+        val mod = i % n
+        if (i + (n - 1) - mod >= 0) unit(mod) else nonNegativeLessThan(n)
+      }
+    assert(checkRNGNonNegativeLessThan(rng, counter, nonNegativeLessThan(limit), limit))
+  }
+
+  test("RNG.mapViaFlatMap")(genRNG ** genCounter) { case (rng, counter) =>
+    assert(checkRND(rng, counter, mapViaFlatMap(int)(_.toString), _.toIntOption.isDefined))
+  }
+
+  test("RNG.map2ViaFlatMap")(genRNG ** genCounter) { case (rng, counter) =>
+    val randC = map2ViaFlatMap(double, double)((d1, d2) => (d1, d2))
+    assert(checkRND(rng, counter, randC, (d1, d2) => isInInterval(d1) && isInInterval(d2) && d1 != d2))
+  }
+
+  private def checkRND[A](rng: RNG, counter: Int, generate: Rand[A], isCorrect: A => Boolean): Boolean =
+    @tailrec
+    def loop(rng: RNG, counter: Int, previousValue: Option[A] = None): Boolean =
+      counter < 0 || {
+        val (value, rng2) = generate(rng)
+        if !isCorrect(value) then fail(s"The generated value '$value' is invalid.")
+        else if previousValue.contains(value) then fail(s"The RNG generated two identical values in a row ('$value').")
+        else loop(rng2, counter - 1, Some(value))
+      }
+    loop(rng, counter)
+
+  private def checkRNGUnit[A](rng: RNG, counter: Int, constantValue: A): Boolean =
+    @tailrec
+    def loop(rng: RNG, counter: Int): Boolean =
+      counter < 0 || {
+        val (value, rng2) = RNG.unit(constantValue)(rng)
+        if constantValue == value then loop(rng2, counter - 1)
+        else fail(s"RNG.unit must always return a constant value ('$constantValue').")
+      }
+    loop(rng, counter)
+
+  private def checkRNGNonNegativeLessThan(rng: RNG, counter: Int, generate: Rand[Int], limit: Int): Boolean =
+    @tailrec
+    def loop(rng: RNG, counter: Int): Boolean =
+      counter < 0 || {
+        val (i, rng2) = generate(rng)
+        if 0 <= i && i < limit then loop(rng2, counter - 1)
+        else fail(s"The generated value '$i' isn't in the interval [0, $limit).")
+      }
+    loop(rng, counter)

--- a/src/test/scala/fpinscala/exercises/state/StateSuite.scala
+++ b/src/test/scala/fpinscala/exercises/state/StateSuite.scala
@@ -1,0 +1,71 @@
+package fpinscala.exercises.state
+
+import fpinscala.answers.testing.exhaustive.*
+import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.Common.*
+import fpinscala.exercises.common.PropSuite
+import fpinscala.exercises.state.State
+import fpinscala.exercises.state.State.*
+
+class StateSuite extends PropSuite:
+  // a - the head element, next state - the tail of the list
+  private val stateA: State[List[String], Option[String]] =
+    State {
+      case Nil          => (None, Nil)
+      case head :: tail => (Some(head), tail)
+    }
+
+  // b - the length of the list, next state - the tail of the list
+  private val stateB: State[List[String], Int] =
+    State {
+      case Nil          => (0, Nil)
+      case head :: tail => (tail.length + 1, tail)
+    }
+
+  /*
+  test("State.unit")(genString) { str =>
+    val (a, s) = unit[Int, String](str).run(0)
+    assertEquals(a, str)
+    assertEquals(s, 0)
+  }
+  */
+
+  test("State.map")(genStringList) { list =>
+    val (b, s) = stateA.map(length).run(list)
+    val expectedB = length(list.headOption)
+    assertEquals(b, expectedB)
+    assertEquals(s, list.drop(1))
+  }
+
+  test("State.map2")(genStringList) { list =>
+    val (c, s) = stateA.map2(stateB)(printResult).run(list)
+    // a - the result of the initial state, b - the result of the next state
+    val expectedC = printResult(list.headOption, list.drop(1).length)
+    // s - the result of passing through two states (after a and b)
+    assertEquals(c, expectedC)
+    assertEquals(s, list.drop(2))
+  }
+
+  /*
+  test("State.flatMap")(genStringList) { list =>
+    val (b, s) = stateA.flatMap(a => unit(length(a))).run(list)
+    val expectedB = length(list.headOption)
+    assertEquals(b, expectedB)
+    assertEquals(s, list.drop(1))
+  }
+
+  test("State.sequence")(genStringList) { list =>
+    val half = list.length / 2
+    val listOfStates = (0 until half).map(_ => stateA).toList
+    val (firstHalfElements, restElements) = sequence(listOfStates).run(list)
+    val (first, rest) = list.splitAt(half)
+    assertEquals(firstHalfElements, first.map(Some(_)))
+    assertEquals(restElements, rest)
+  }
+  */
+
+  private def length(maybeHead: Option[String]): Int =
+    maybeHead.getOrElse("").length
+
+  private def printResult(maybeHead: Option[String], length: Int): String =
+    s"The head element is '$maybeHead', the length is $length"


### PR DESCRIPTION
Added unit-tests for chapters 5 and 6.

I had to add `lazy` for some variables in `fpinscala/exercises/laziness/LazyList.scala` because if not:
The readers will not be able to run `LazyListSuite` before these three variables are implemented because `genLazyList` will not be created.
But the reader should be able to run the tests one at a time to complete exercise after exercise.

