### PR TITLE
Fix Exercise 9.6 answers

### DIFF
--- a/answerkey/parsing/06.answer.scala
+++ b/answerkey/parsing/06.answer.scala
@@ -6,8 +6,8 @@ val nonNegativeInt: Parser[Int] =
       case None => fail("expected an integer")
   yield n
 
-val nConsecutiveAs: Parser[Int] = 
+val nConsecutiveAs: Parser[String] =
   for
     n <- nonNegativeInt
-    _ <- char('a').listOfN(n)
-  yield n
+    s <- char('a').listOfN(n).map(list => s"$n${list.mkString}")
+  yield s

--- a/src/main/scala/fpinscala/answers/parsing/Parsers.scala
+++ b/src/main/scala/fpinscala/answers/parsing/Parsers.scala
@@ -228,9 +228,9 @@ class Examples[Parser[+_]](P: Parsers[Parser]):
         case None => fail("expected an integer")
     yield n
 
-  val nConsecutiveAs: Parser[Int] = 
+  val nConsecutiveAs: Parser[String] =
     for
       n <- nonNegativeInt
-      _ <- char('a').listOfN(n)
-    yield n
+      s <- char('a').listOfN(n).map(list => s"$n${list.mkString}")
+    yield s
 


### PR DESCRIPTION
In Exercise 9.6 we see the following task:

> Suppose we want to parse a single digit, like '4', followed by that many 'a' characters (this sort of problem should feel familiar from previous chapters). Examples of valid input are "0", "1a", "2aa", "4aaaa", and so on. 

But in the answers we get `nConsecutiveAs` same as `nonNegativeInt` which just return a digit.

And we have the following results:
```
nConsecutiveAs.run("0") == Right(0)
nConsecutiveAs.run("1a") == Right(1)
nConsecutiveAs.run("2aa") == Right(2)
nConsecutiveAs.run("4aaaa") == Right(3)
```

Maybe we can use the folloving implementation?
In this case we get the result:
```
nConsecutiveAs.run("0") == Right("0")
nConsecutiveAs.run("1a") == Right("1a")
nConsecutiveAs.run("2aa") == Right("2aa")
nConsecutiveAs.run("4aaaa") == Right("4aaaa")
```

