### PR TITLE
Adding unit-tests for chapter 9

### DIFF
--- a/src/main/scala/fpinscala/exercises/parsing/JSON.scala
+++ b/src/main/scala/fpinscala/exercises/parsing/JSON.scala
@@ -1,0 +1,12 @@
+package fpinscala.exercises.parsing
+
+enum JSON:
+  case JNull
+  case JNumber(get: Double)
+  case JString(get: String)
+  case JBool(get: Boolean)
+  case JArray(get: IndexedSeq[JSON])
+  case JObject(get: Map[String, JSON])
+
+object JSON:
+  def jsonParser[Parser[+_]](P: Parsers[Parser]): Parser[JSON] = ???

--- a/src/main/scala/fpinscala/exercises/parsing/Parsers.scala
+++ b/src/main/scala/fpinscala/exercises/parsing/Parsers.scala
@@ -23,6 +23,10 @@ case class Location(input: String, offset: Int = 0) {
 
   def advanceBy(n: Int) = copy(offset = offset+n)
 
+  def remaining: String = ???
+
+  def slice(n: Int) = ???
+
   /* Returns the line corresponding to this location */
   def currentLine: String = 
     if (input.length > 1) input.linesIterator.drop(line-1).next()
@@ -30,5 +34,14 @@ case class Location(input: String, offset: Int = 0) {
 }
 
 case class ParseError(stack: List[(Location,String)] = List(),
-                      otherFailures: List[ParseError] = List()) {
-}
+                      otherFailures: List[ParseError] = List()):
+  def push(loc: Location, msg: String): ParseError = ???
+
+  def label(s: String): ParseError = ???
+
+class Examples[Parser[+_]](P: Parsers[Parser]):
+  import P.*
+
+  val nonNegativeInt: Parser[Int] = ???
+
+  val nConsecutiveAs: Parser[Int] = ???

--- a/src/test/scala/fpinscala/exercises/parsing/JSONSuite.scala
+++ b/src/test/scala/fpinscala/exercises/parsing/JSONSuite.scala
@@ -1,0 +1,211 @@
+package fpinscala.exercises.parsing
+
+import fpinscala.answers.testing.exhaustive.*
+import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.Common.*
+import fpinscala.exercises.common.PropSuite
+import fpinscala.exercises.parsing.JSON.*
+import fpinscala.exercises.parsing.{JSON, Parsers}
+
+// Exercise 9.9
+class JSONSuite extends PropSuite:
+  private val parser = JSON.jsonParser(UnitTestParser)
+
+  test("JSON.JNull")(Gen.unit(())) { _ =>
+    assertEquals(parser.run("""{ "key": null }"""), Right(JObject(Map("key" -> JNull))))
+    assertEquals(parser.run("""[ null ]"""), Right(JArray(IndexedSeq(JNull))))
+    assertEquals(
+      parser.run("""[ null, null, null ]"""),
+      Right(JArray(IndexedSeq(JNull, JNull, JNull)))
+    )
+  }
+
+  test("JSON.JNumber")(Gen.double ** Gen.double ** Gen.double) { case ((d1, d2), d3) =>
+    assertEquals(parser.run(s"""{ "key": $d1 }"""), Right(JObject(Map("key" -> JNumber(d1)))))
+    assertEquals(parser.run(s"""[ $d1 ]"""), Right(JArray(IndexedSeq(JNumber(d1)))))
+    assertEquals(
+      parser.run(s"""[ $d1, $d2, $d3 ]"""),
+      Right(JArray(IndexedSeq(JNumber(d1), JNumber(d2), JNumber(d3))))
+    )
+  }
+
+  test("JSON.JString")(genString ** genString ** genString) { case ((s1, s2), s3) =>
+    assertEquals(parser.run(s"""{ "key": "$s1" }"""), Right(JObject(Map("key" -> JString(s1)))))
+    assertEquals(parser.run(s"""[ "$s1" ]"""), Right(JArray(IndexedSeq(JString(s1)))))
+    assertEquals(
+      parser.run(s"""[ "$s1", "$s2", "$s3" ]"""),
+      Right(JArray(IndexedSeq(JString(s1), JString(s2), JString(s3))))
+    )
+  }
+
+  test("JSON.JBool")(Gen.boolean ** Gen.boolean ** Gen.boolean) { case ((b1, b2), b3) =>
+    assertEquals(parser.run(s"""{ "key": $b1 }"""), Right(JObject(Map("key" -> JBool(b1)))))
+    assertEquals(parser.run(s"""[ $b1 ]"""), Right(JArray(IndexedSeq(JBool(b1)))))
+    assertEquals(
+      parser.run(s"""[ $b1, $b2, $b3 ]"""),
+      Right(JArray(IndexedSeq(JBool(b1), JBool(b2), JBool(b3))))
+    )
+  }
+
+  test("JSON.JArray")(Gen.double ** genString ** Gen.boolean) { case ((d, s), b) =>
+    assertEquals(parser.run("[ ]"), Right(JArray(IndexedSeq.empty[JSON])))
+    assertEquals(
+      parser.run(s"""[ null, $d, "$s", $b ]"""),
+      Right(JArray(IndexedSeq(JNull, JNumber(d), JString(s), JBool(b))))
+    )
+    assertEquals(
+      parser.run(s"""[ null, [ $d, [ "$s", $b ] ] ]"""),
+      Right(
+        JArray(
+          IndexedSeq(
+            JNull,
+            JArray(IndexedSeq(JNumber(d), JArray(IndexedSeq(JString(s), JBool(b)))))
+          )
+        )
+      )
+    )
+  }
+
+  private val jObjectJson1 = """
+    {
+      "Company name" : "Microsoft Corporation",
+      "Ticker"  : "MSFT",
+      "Active"  : true,
+      "Price"   : 30.66,
+      "Shares outstanding" : 8.38e9,
+      "Related companies" : [ "HPQ", "IBM", "YHOO", "DELL", "GOOG" ]
+    }
+    """
+
+  test("JSON.JObject, 1")(Gen.unit(())) { _ =>
+    assertEquals(
+      parser.run(jObjectJson1),
+      Right(
+        JObject(
+          Map(
+            "Company name" -> JString("Microsoft Corporation"),
+            "Ticker" -> JString("MSFT"),
+            "Active" -> JBool(true),
+            "Price" -> JNumber(30.66),
+            "Shares outstanding" -> JNumber(8.38e9),
+            "Related companies" -> JArray(
+              IndexedSeq(JString("HPQ"), JString("IBM"), JString("YHOO"), JString("DELL"), JString("GOOG"))
+            )
+          )
+        )
+      )
+    )
+  }
+
+  private val jObjectJson2 = """
+    {
+      "Book"   : "Functional Programming in Scala, Second Edition",
+      "Active" : true,
+      "Pages"  : 322,
+      "Parts" : {
+        "Part 1" : {
+          "Title" : "Introduction to functional programming",
+          "Content" : [
+            {
+              "Chapter 1": {
+                "Title" : "What is functional programming?",
+                "Content" : [
+                  "1.1 The benefits of FP: a simple example",
+                  [
+                    "1.1.1 A program with side effects",
+                    "1.1.2 A functional solution: removing the side effects"
+                  ]
+                ]
+              }
+            }
+          ]
+        }
+      }
+    }
+    """
+
+  test("JSON.JObject, 2")(Gen.unit(())) { _ =>
+    assertEquals(
+      parser.run(jObjectJson2),
+      Right(
+        JObject(
+          Map(
+            "Book" -> JString("Functional Programming in Scala, Second Edition"),
+            "Active" -> JBool(true),
+            "Pages" -> JNumber(322),
+            "Parts" -> JObject(
+              Map(
+                "Part 1" -> JObject(
+                  Map(
+                    "Title" -> JString("Introduction to functional programming"),
+                    "Content" -> JArray(
+                      IndexedSeq(
+                        JObject(
+                          Map(
+                            "Chapter 1" -> JObject(
+                              Map(
+                                "Title" -> JString("What is functional programming?"),
+                                "Content" -> JArray(
+                                  IndexedSeq(
+                                    JString("1.1 The benefits of FP: a simple example"),
+                                    JArray(
+                                      IndexedSeq(
+                                        JString("1.1.1 A program with side effects"),
+                                        JString("1.1.2 A functional solution: removing the side effects")
+                                      )
+                                    )
+                                  )
+                                )
+                              )
+                            )
+                          )
+                        )
+                      )
+                    )
+                  )
+                )
+              )
+            )
+          )
+        )
+      )
+    )
+  }
+
+  private val genMalformedJSONs: Gen[String] =
+    IndexedSeq(
+      """
+    "Company name"
+    """,
+      """
+    "Company name" : "Microsoft Corporation"
+    """,
+      """
+    {
+      "Company name" : "Microsoft Corporation"
+    """,
+      """
+      "Company name" : "Microsoft Corporation"
+    }
+    """,
+      """
+    {
+      "Company name" ; "Microsoft Corporation"
+    }
+    """,
+      """
+    [ "HPQ" "IBM" ]
+    """,
+      """
+    [
+      [ "HPQ", "IBM",
+      "YHOO", "DELL" ++
+      "GOOG"
+      ]
+    ]
+    """
+    ).map(Gen.unit).reduce(Gen.union)
+
+  test("malformed JSONs")(genMalformedJSONs) { json =>
+    assert(parser.run(json).isLeft)
+  }

--- a/src/test/scala/fpinscala/exercises/parsing/JSONSuite.scala
+++ b/src/test/scala/fpinscala/exercises/parsing/JSONSuite.scala
@@ -1,6 +1,7 @@
 package fpinscala.exercises.parsing
 
 import fpinscala.answers.testing.exhaustive.*
+import fpinscala.answers.testing.exhaustive.Gen.`**`
 import fpinscala.answers.testing.exhaustive.Prop.*
 import fpinscala.exercises.common.Common.*
 import fpinscala.exercises.common.PropSuite
@@ -20,7 +21,7 @@ class JSONSuite extends PropSuite:
     )
   }
 
-  test("JSON.JNumber")(Gen.double ** Gen.double ** Gen.double) { case ((d1, d2), d3) =>
+  test("JSON.JNumber")(Gen.double ** Gen.double ** Gen.double) { case d1 ** d2 ** d3 =>
     assertEquals(parser.run(s"""{ "key": $d1 }"""), Right(JObject(Map("key" -> JNumber(d1)))))
     assertEquals(parser.run(s"""[ $d1 ]"""), Right(JArray(IndexedSeq(JNumber(d1)))))
     assertEquals(
@@ -29,7 +30,7 @@ class JSONSuite extends PropSuite:
     )
   }
 
-  test("JSON.JString")(genString ** genString ** genString) { case ((s1, s2), s3) =>
+  test("JSON.JString")(genString ** genString ** genString) { case s1 ** s2 ** s3 =>
     assertEquals(parser.run(s"""{ "key": "$s1" }"""), Right(JObject(Map("key" -> JString(s1)))))
     assertEquals(parser.run(s"""[ "$s1" ]"""), Right(JArray(IndexedSeq(JString(s1)))))
     assertEquals(
@@ -38,7 +39,7 @@ class JSONSuite extends PropSuite:
     )
   }
 
-  test("JSON.JBool")(Gen.boolean ** Gen.boolean ** Gen.boolean) { case ((b1, b2), b3) =>
+  test("JSON.JBool")(Gen.boolean ** Gen.boolean ** Gen.boolean) { case b1 ** b2 ** b3 =>
     assertEquals(parser.run(s"""{ "key": $b1 }"""), Right(JObject(Map("key" -> JBool(b1)))))
     assertEquals(parser.run(s"""[ $b1 ]"""), Right(JArray(IndexedSeq(JBool(b1)))))
     assertEquals(
@@ -47,7 +48,7 @@ class JSONSuite extends PropSuite:
     )
   }
 
-  test("JSON.JArray")(Gen.double ** genString ** Gen.boolean) { case ((d, s), b) =>
+  test("JSON.JArray")(Gen.double ** genString ** Gen.boolean) { case d ** s ** b =>
     assertEquals(parser.run("[ ]"), Right(JArray(IndexedSeq.empty[JSON])))
     assertEquals(
       parser.run(s"""[ null, $d, "$s", $b ]"""),

--- a/src/test/scala/fpinscala/exercises/parsing/ParsersSuite.scala
+++ b/src/test/scala/fpinscala/exercises/parsing/ParsersSuite.scala
@@ -1,0 +1,149 @@
+package fpinscala.exercises.parsing
+
+import fpinscala.answers.testing.exhaustive.*
+import fpinscala.answers.testing.exhaustive.Prop.*
+import fpinscala.exercises.common.Common.*
+import fpinscala.exercises.common.PropSuite
+import fpinscala.exercises.parsing.Parsers
+
+class ParsersSuite extends PropSuite:
+  import UnitTestParser.*
+
+  /*
+  test("Parsers.char")(genChar) { c =>
+    assertEquals(char(c).run(c.toString), Right(c))
+    val anotherChar = (c + 1).toChar
+    assert(char(c).run(anotherChar.toString).isLeft)
+  }
+
+  test("Parsers.string")(genString) { s =>
+    assertEquals(string(s).run(s), Right(s))
+
+    val nonEmptyS = s"a$s"
+    val anotherString = s"b$s"
+    assert(string(nonEmptyS).run(anotherString).isLeft)
+  }
+
+  test("Parsers.or")(Gen.unit(())) { _ =>
+    val orParser = string("abra").or(string("cadabra"))
+    assertEquals(orParser.run("abra"), Right("abra"))
+    assertEquals(orParser.run("cadabra"), Right("cadabra"))
+    assert(orParser.run("error").isLeft)
+
+    val or1Parser = string("abra") | string("cadabra")
+    assertEquals(or1Parser.run("abra"), Right("abra"))
+    assertEquals(or1Parser.run("cadabra"), Right("cadabra"))
+    assert(or1Parser.run("error").isLeft)
+  }
+
+  test("Parsers.listOfN")(Gen.unit(())) { _ =>
+    val p = (string("ab") | string("cad")).listOfN(3)
+    assertEquals(p.run("ababcad"), Right(List("ab", "ab", "cad")))
+    assertEquals(p.run("cadabab"), Right(List("cad", "ab", "ab")))
+    assertEquals(p.run("ababab"), Right(List("ab", "ab", "ab")))
+    assertEquals(p.run("cadcadcad"), Right(List("cad", "cad", "cad")))
+    assertEquals(p.run("ababcad_any_another_string"), Right(List("ab", "ab", "cad")))
+    assert(p.run("abab").isLeft)
+  }
+
+  test("Parsers.many")(Gen.unit(())) { _ =>
+    val numA: Parser[Int] = char('a').many.map(_.size)
+    assertEquals(numA.run("aaa"), Right(3))
+    assertEquals(numA.run("a"), Right(1))
+    assertEquals(numA.run("b"), Right(0))
+  }
+
+  test("Parsers.succeed")(genString) { s =>
+    assertEquals(succeed("succeed").run(s), Right("succeed"))
+  }
+
+  test("Parsers.slice")(Gen.unit(())) { _ =>
+    assertEquals((char('a') | char('b')).many.slice.run("aaba"), Right("aaba"))
+  }
+
+  test("Exercise 9.1, map2")(Gen.unit(())) { _ =>
+    val parserA = char('a')
+    val parserB = char('b')
+    val parserC = parserA.map2(parserB)((a, b) => s"$a$b")
+    assertEquals(parserC.run("ab"), Right("ab"))
+    assert(parserC.run("ba").isLeft)
+    assert(parserC.run("aa").isLeft)
+    assert(parserC.run("a").isLeft)
+    assert(parserC.run("b").isLeft)
+    assert(parserC.run("c").isLeft)
+  }
+
+  test("Exercise 9.1, many1")(Gen.unit(())) { _ =>
+    val numA: Parser[Int] = char('a').many1.map(_.size)
+    assertEquals(numA.run("aaa"), Right(3))
+    assertEquals(numA.run("a"), Right(1))
+    assert(numA.run("b").isLeft)
+
+    val zeroOrMoreAFollowedByOneOrMoreB = char('a').many.slice.map(_.length) ** char('b').many1.slice.map(_.length)
+    assertEquals(zeroOrMoreAFollowedByOneOrMoreB.run("bbb"), Right((0, 3)))
+    assertEquals(zeroOrMoreAFollowedByOneOrMoreB.run("abbb"), Right((1, 3)))
+    assertEquals(zeroOrMoreAFollowedByOneOrMoreB.run("aaabbb"), Right((3, 3)))
+    assertEquals(zeroOrMoreAFollowedByOneOrMoreB.run("b"), Right((0, 1)))
+    assertEquals(zeroOrMoreAFollowedByOneOrMoreB.run("ab"), Right((1, 1)))
+    assertEquals(zeroOrMoreAFollowedByOneOrMoreB.run("aaab"), Right((3, 1)))
+    assert(zeroOrMoreAFollowedByOneOrMoreB.run("").isLeft)
+    assert(zeroOrMoreAFollowedByOneOrMoreB.run("a").isLeft)
+    assert(zeroOrMoreAFollowedByOneOrMoreB.run("aaa").isLeft)
+    assertEquals(zeroOrMoreAFollowedByOneOrMoreB.run("aaabbbab"), Right((3, 3)))
+    assert(zeroOrMoreAFollowedByOneOrMoreB.run("c").isLeft)
+  }
+
+  private val lawsParser: Gen[(Parser[Char], Parser[Char], Parser[Char], String, String)] =
+    for
+      a <- genChar
+      b <- genChar
+      c <- genChar
+    yield (char(a), char(b), char(c), s"$a$b$c", s"$a$a$a")
+
+  test("Exercise 9.2")(lawsParser) { case (a, b, c, success, failure) =>
+    val parserL = ((a ** b) ** c).map(unbiasL)
+    val parserR = (a ** (b ** c)).map(unbiasR)
+    assertEquals(parserL.run(success), parserR.run(success))
+    assertEquals(parserL.run(failure), parserR.run(failure))
+
+    val f: Char => String = c => s"$c$c"
+    val g: Char => String = c => s"$c$c$c"
+    val productOfMapParser = a.map(f) ** b.map(g)
+    val mapOfProductParser = (a ** b).map((a, b) => (f(a), g(b)))
+    assertEquals(productOfMapParser.run(success), mapOfProductParser.run(success))
+    assertEquals(productOfMapParser.run(failure), mapOfProductParser.run(failure))
+  }
+
+  private val examples = new Examples(UnitTestParser)
+  import examples.*
+
+  private val genNonNegativeIntExamples: Gen[(Int, Char, String)] =
+    for
+      posInt <- Gen.int.map(_.abs)
+      char <- genChar
+      str <- genString
+    yield (posInt, char, str)
+
+  test("Exercise 9.6, nonNegativeInt")(genNonNegativeIntExamples) { case (posInt, char, str) =>
+    assertEquals(nonNegativeInt.run(posInt.toString), Right(posInt))
+    assert(nonNegativeInt.run(s"-$posInt").isLeft)
+    assert(nonNegativeInt.run(char.toString).isLeft)
+    assert(nonNegativeInt.run(str).isLeft)
+  }
+
+  test("Exercise 9.6, nConsecutiveAs")(Gen.unit(())) { _ =>
+    assertEquals(nConsecutiveAs.run("0"), Right(0))
+    assertEquals(nConsecutiveAs.run("1a"), Right(1))
+    assertEquals(nConsecutiveAs.run("2aa"), Right(2))
+    assertEquals(nConsecutiveAs.run("4aaaa"), Right(4))
+    assertEquals(nConsecutiveAs.run("0aaaa"), Right(0))
+    assertEquals(nConsecutiveAs.run("2aaaa"), Right(2))
+    assert(nConsecutiveAs.run("4bcde").isLeft)
+    assert(nConsecutiveAs.run("4baaa").isLeft)
+    assert(nConsecutiveAs.run("aaaa").isLeft)
+    assert(nConsecutiveAs.run("-4aaaa").isLeft)
+  }
+
+  private def unbiasL[A, B, C](p: ((A, B), C)): (A, B, C) = (p(0)(0), p(0)(1), p(1))
+  private def unbiasR[A, B, C](p: (A, (B, C))): (A, B, C) = (p(0), p(1)(0), p(1)(1))
+  */

--- a/src/test/scala/fpinscala/exercises/parsing/UnitTestParser.scala
+++ b/src/test/scala/fpinscala/exercises/parsing/UnitTestParser.scala
@@ -1,0 +1,102 @@
+package fpinscala.exercises.parsing
+
+import fpinscala.exercises.parsing.Parsers
+
+import scala.util.matching.Regex
+
+/** This is similar to `fpinscala.answers.parsing.Reference` but using `fpinscala.exercises.parsing.Parsers`.
+ *
+ * @see
+ *   [[fpinscala.answers.parsing.Reference]]
+ */
+object UnitTestParser extends Parsers[UnitTestParser.Parser]:
+  type Parser[+A] = Location => Result[A]
+
+  enum Result[+A]:
+    case Success(get: A, length: Int)
+    case Failure(get: ParseError, isCommitted: Boolean) extends Result[Nothing]
+
+    def extract: Either[ParseError, A] = this match
+      case Failure(e, _) => Left(e)
+      case Success(a, _) => Right(a)
+
+    def uncommit: Result[A] = this match
+      case Failure(e, true) => Failure(e, false)
+      case _                => this
+
+    def addCommit(isCommitted: Boolean): Result[A] = this match
+      case Failure(e, c) => Failure(e, c || isCommitted)
+      case _             => this
+
+    def mapError(f: ParseError => ParseError): Result[A] = this match
+      case Failure(e, c) => Failure(f(e), c)
+      case _             => this
+
+    def advanceSuccess(n: Int): Result[A] = this match
+      case Success(a, m) => Success(a, n + m)
+      case _             => this
+
+  import Result.{Failure, Success}
+
+  def succeed[A](a: A): Parser[A] =
+    _ => Success(a, 0)
+
+  def fail(msg: String): Parser[Nothing] =
+    l => Failure(l.toError(msg), true)
+
+  /** Returns -1 if s1.startsWith(s2), otherwise returns the first index where the two strings differed. If s2 is longer
+   * than s1, returns s1.length.
+   */
+  def firstNonmatchingIndex(s1: String, s2: String, offset: Int): Int =
+    var i = 0
+    while (i + offset < s1.length && i < s2.length)
+      if s1.charAt(i + offset) != s2.charAt(i) then return i
+      i += 1
+    if s1.length - offset >= s2.length then -1
+    else s1.length - offset
+
+  def string(w: String): Parser[String] =
+    l =>
+      val i = firstNonmatchingIndex(l.input, w, l.offset)
+      if i == -1 then Success(w, w.length)
+      else Failure(l.advanceBy(i).toError(s"'$w'"), i != 0)
+
+  def regex(r: Regex): Parser[String] =
+    l =>
+      r.findPrefixOf(l.remaining) match
+        case None    => Failure(l.toError(s"regex $r"), false)
+        case Some(m) => Success(m, m.length)
+
+  extension [A](p: Parser[A])
+
+    def run(s: String): Either[ParseError, A] =
+      p(Location(s)).extract
+
+    def or(p2: => Parser[A]): Parser[A] =
+      l =>
+        p(l) match
+          case Failure(e, false) => p2(l)
+          case r                 => r
+
+    def attempt: Parser[A] = l => p(l).uncommit
+
+    def flatMap[B](f: A => Parser[B]): Parser[B] =
+      l =>
+        p(l) match
+          case Success(a, n) =>
+            f(a)(l.advanceBy(n))
+              .addCommit(n != 0)
+              .advanceSuccess(n)
+          case f @ Failure(_, _) => f
+
+    def slice: Parser[String] =
+      l =>
+        p(l) match
+          case Success(a, n)     => Success(l.slice(n), n)
+          case f @ Failure(_, _) => f
+
+    def scope(msg: String): Parser[A] =
+      l => p(l).mapError(_.push(l, msg))
+
+    def label(msg: String): Parser[A] =
+      l => p(l).mapError(_.label(msg))


### PR DESCRIPTION
Adding unit tests for chapter 9 is difficult because we define the signature of `Parsers` when we read the chapter and can't set it ahead of time.

Maybe the such implementation is OK?