### PR TITLE
NI - Fixed infinite loop

### DIFF
--- a/src/main/scala/fpinscala/exercises/monads/Monad.scala
+++ b/src/main/scala/fpinscala/exercises/monads/Monad.scala
@@ -73,7 +73,7 @@ object Monad:
     def unit[A](a: => A): Gen[A] = Gen.unit(a)
     extension [A](fa: Gen[A])
       override def flatMap[B](f: A => Gen[B]): Gen[B] =
-        fa.flatMap(f)
+        Gen.flatMap(fa)(f)
 
   given parMonad: Monad[Par] with
     def unit[A](a: => A) = ???

--- a/src/main/scala/fpinscala/exercises/testing/Gen.scala
+++ b/src/main/scala/fpinscala/exercises/testing/Gen.scala
@@ -21,6 +21,9 @@ object Prop:
 object Gen:
   def unit[A](a: => A): Gen[A] = ???
 
+  extension [A](self: Gen[A])
+    def flatMap[B](f: A => Gen[B]): Gen[B] = ???
+
 trait Gen[A]:
   def map[B](f: A => B): Gen[B] = ???
   def flatMap[B](f: A => Gen[B]): Gen[B] = ???

--- a/src/main/scala/fpinscala/exercises/testing/Gen.scala
+++ b/src/main/scala/fpinscala/exercises/testing/Gen.scala
@@ -22,7 +22,7 @@ object Gen:
   def unit[A](a: => A): Gen[A] = ???
 
 trait Gen[A]:
-  def map[A,B](f: A => B): Gen[B] = ???
-  def flatMap[A,B](f: A => Gen[B]): Gen[B] = ???
+  def map[B](f: A => B): Gen[B] = ???
+  def flatMap[B](f: A => Gen[B]): Gen[B] = ???
 
 trait SGen[+A]


### PR DESCRIPTION
We have infinite loop in this place:
https://github.com/fpinscala/fpinscala/blob/second-edition/src/main/scala/fpinscala/exercises/monads/Monad.scala#L76

because we have an error in this place:
https://github.com/fpinscala/fpinscala/blob/second-edition/src/main/scala/fpinscala/exercises/testing/Gen.scala#L26

We already defined `A` type for trait `trait Gen[A]:` and if we define `flatMap` like this
`def flatMap[A,B](f: A => Gen[B]): Gen[B] = ???`, we will get three different type: `A` (from trait), `A` (from method), `B` (from method).
This is the reason for the infinite loop in the monad:
https://github.com/fpinscala/fpinscala/blob/second-edition/src/main/scala/fpinscala/exercises/monads/Monad.scala#L76

Because `flatMap` defined in the monad will be taken, and not in `Gen`