### PR TITLE
Fixed an error in the applicative/03.answer.md

### DIFF
--- a/answerkey/applicative/03.answer.md
+++ b/answerkey/applicative/03.answer.md
@@ -6,7 +6,7 @@ Each call to `apply` is a partial application of the function
 */
 extension [A](fa: F[A])
   def map[B](f: A => B): F[B] =
-    apply(f.curried)(fa)
+    apply(unit(f))(fa)
   
   def map2[B, C](fb: F[B])(f: (A, B) => B): F[C] =
     apply(fa.map(f.curried))(fb)
@@ -22,6 +22,6 @@ extension [A](fa: F[A])
     fc: F[C],
     fd: F[D]
   )(f: (A, B, C, D) => E): F[E] =
-    apply(fa.map3(fb, fc)((a, b, c) => f(a, b, c, _)))(fc)
+    apply(fa.map3(fb, fc)((a, b, c) => f(a, b, c, _)))(fd)
 
 ```


### PR DESCRIPTION
Method `apply` takes an argument of type `F[_]` and we can't use `f.curried`, we should use `unit(f)`.

And there is a typo in 25 row