### PR TITLE
Stream has been replaced with LazyList

### DIFF
--- a/answerkey/laziness/01.answer.md
+++ b/answerkey/laziness/01.answer.md
@@ -15,7 +15,7 @@ correct order again.
 */
 def toList: List[A] = {
   @annotation.tailrec
-  def go(s: Stream[A], acc: List[A]): List[A] = s match {
+  def go(s: LazyList[A], acc: List[A]): List[A] = s match {
     case Cons(h,t) => go(t(), h() :: acc)
     case _ => acc
   }
@@ -31,7 +31,7 @@ still _pure_.
 def toListFast: List[A] = {
   val buf = new collection.mutable.ListBuffer[A] 
   @annotation.tailrec
-  def go(s: Stream[A]): List[A] = s match {
+  def go(s: LazyList[A]): List[A] = s match {
     case Cons(h,t) =>
       buf += h()
       go(t())

--- a/answerkey/laziness/02.answer.md
+++ b/answerkey/laziness/02.answer.md
@@ -3,7 +3,7 @@
 /*
 `take` first checks if n==0. In that case we need not look at the stream at all.
 */
-def take(n: Int): Stream[A] = this match {
+def take(n: Int): LazyList[A] = this match {
   case Cons(h, t) if n > 1 => cons(h(), t().take(n - 1))
   case Cons(h, _) if n == 1 => cons(h(), empty)
   case _ => empty
@@ -15,7 +15,7 @@ Unlike `take`, `drop` is not incremental. That is, it doesn't generate the
 answer lazily. It must traverse the first `n` elements of the stream eagerly.
 */
 @annotation.tailrec
-final def drop(n: Int): Stream[A] = this match {
+final def drop(n: Int): LazyList[A] = this match {
   case Cons(_, t) if n > 0 => t().drop(n - 1)
   case _ => this
 }

--- a/answerkey/laziness/02.hint.md
+++ b/answerkey/laziness/02.hint.md
@@ -1,1 +1,1 @@
-Many `Stream` functions can start by pattern matching on the `Stream` and considering what to do in each of the two cases. This particular function needs to first consider whether it needs to look at the stream at all.
+Many `LazyList` functions can start by pattern matching on the `LazyList` and considering what to do in each of the two cases. This particular function needs to first consider whether it needs to look at the stream at all.

--- a/answerkey/laziness/03.answer.md
+++ b/answerkey/laziness/03.answer.md
@@ -2,7 +2,7 @@
 /*
 It's a common Scala style to write method calls without `.` notation, as in `t() takeWhile f`.  
 */
-def takeWhile(f: A => Boolean): Stream[A] = this match { 
+def takeWhile(f: A => Boolean): LazyList[A] = this match { 
   case Cons(h,t) if f(h()) => cons(h(), t() takeWhile f)
   case _ => empty 
 }

--- a/answerkey/laziness/05.answer.md
+++ b/answerkey/laziness/05.answer.md
@@ -1,5 +1,5 @@
 ```scala
-def takeWhile_1(f: A => Boolean): Stream[A] =
+def takeWhile_1(f: A => Boolean): LazyList[A] =
   foldRight(empty[A])((h,t) => 
     if (f(h)) cons(h,t)
     else      empty)

--- a/answerkey/laziness/07.answer.md
+++ b/answerkey/laziness/07.answer.md
@@ -1,16 +1,16 @@
 ```scala
-def map[B](f: A => B): Stream[B] =
+def map[B](f: A => B): LazyList[B] =
   foldRight(empty[B])((h,t) => cons(f(h), t)) 
 
-def filter(f: A => Boolean): Stream[A] =
+def filter(f: A => Boolean): LazyList[A] =
   foldRight(empty[A])((h,t) => 
     if (f(h)) cons(h, t)
     else t) 
 
-def append[B>:A](s: => Stream[B]): Stream[B] = 
+def append[B>:A](s: => LazyList[B]): LazyList[B] = 
   foldRight(s)((h,t) => cons(h,t))
 
-def flatMap[B](f: A => Stream[B]): Stream[B] = 
+def flatMap[B](f: A => LazyList[B]): LazyList[B] = 
   foldRight(empty[B])((h,t) => f(h) append t)
 
 ```

--- a/answerkey/laziness/08.answer.md
+++ b/answerkey/laziness/08.answer.md
@@ -1,8 +1,8 @@
 ```scala
 // This is more efficient than `cons(a, constant(a))` since it's just
 // one object referencing itself.
-def constant[A](a: A): Stream[A] = {
-  lazy val tail: Stream[A] = Cons(() => a, () => tail) 
+def constant[A](a: A): LazyList[A] = {
+  lazy val tail: LazyList[A] = Cons(() => a, () => tail) 
   tail
 }
 ```

--- a/answerkey/laziness/09.answer.md
+++ b/answerkey/laziness/09.answer.md
@@ -1,4 +1,4 @@
 ```scala
-def from(n: Int): Stream[Int] =
+def from(n: Int): LazyList[Int] =
   cons(n, from(n+1))
 ```

--- a/answerkey/laziness/10.answer.md
+++ b/answerkey/laziness/10.answer.md
@@ -1,6 +1,6 @@
 ```scala
 val fibs = {
-  def go(f0: Int, f1: Int): Stream[Int] = 
+  def go(f0: Int, f1: Int): LazyList[Int] = 
     cons(f0, go(f1, f0+f1))
   go(0, 1)
 }

--- a/answerkey/laziness/11.answer.md
+++ b/answerkey/laziness/11.answer.md
@@ -1,5 +1,5 @@
 ```scala
-def unfold[A, S](z: S)(f: S => Option[(A, S)]): Stream[A] =
+def unfold[A, S](z: S)(f: S => Option[(A, S)]): LazyList[A] =
   f(z) match {
     case Some((h,s)) => cons(h, unfold(s)(f))
     case None => empty

--- a/answerkey/laziness/13.answer.md
+++ b/answerkey/laziness/13.answer.md
@@ -1,24 +1,24 @@
 ```scala
-def mapViaUnfold[B](f: A => B): Stream[B] =
+def mapViaUnfold[B](f: A => B): LazyList[B] =
   unfold(this) {
     case Cons(h,t) => Some((f(h()), t()))
     case _ => None
   }
 
-def takeViaUnfold(n: Int): Stream[A] =
+def takeViaUnfold(n: Int): LazyList[A] =
   unfold((this,n)) {
     case (Cons(h,t), 1) => Some((h(), (empty, 0)))
     case (Cons(h,t), n) if n > 1 => Some((h(), (t(), n-1)))
     case _ => None
   }
 
-def takeWhileViaUnfold(f: A => Boolean): Stream[A] =
+def takeWhileViaUnfold(f: A => Boolean): LazyList[A] =
   unfold(this) {
     case Cons(h,t) if f(h()) => Some((h(), t()))
     case _ => None
   }
 
-def zipWith[B,C](s2: Stream[B])(f: (A,B) => C): Stream[C] =
+def zipWith[B,C](s2: LazyList[B])(f: (A,B) => C): LazyList[C] =
   unfold((this, s2)) {
     case (Cons(h1,t1), Cons(h2,t2)) =>
       Some((f(h1(), h2()), (t1(), t2())))
@@ -26,15 +26,15 @@ def zipWith[B,C](s2: Stream[B])(f: (A,B) => C): Stream[C] =
   }
 
 // special case of `zipWith`
-def zip[B](s2: Stream[B]): Stream[(A,B)] =
+def zip[B](s2: LazyList[B]): LazyList[(A,B)] =
   zipWith(s2)((_,_))
 
 
-def zipAll[B](s2: Stream[B]): Stream[(Option[A],Option[B])] =
+def zipAll[B](s2: LazyList[B]): LazyList[(Option[A],Option[B])] =
   zipWithAll(s2)((_,_))
 
-def zipWithAll[B, C](s2: Stream[B])(f: (Option[A], Option[B]) => C): Stream[C] =
-  Stream.unfold((this, s2)) {
+def zipWithAll[B, C](s2: LazyList[B])(f: (Option[A], Option[B]) => C): LazyList[C] =
+  LazyList.unfold((this, s2)) {
     case (Empty, Empty) => None
     case (Cons(h, t), Empty) => Some(f(Some(h()), Option.empty[B]) -> (t(), empty[B]))
     case (Empty, Cons(h, t)) => Some(f(Option.empty[A], Some(h())) -> (empty[A] -> t()))

--- a/answerkey/laziness/14.answer.md
+++ b/answerkey/laziness/14.answer.md
@@ -2,7 +2,7 @@
 /* 
 `s startsWith s2` when corresponding elements of `s` and `s2` are all equal, until the point that `s2` is exhausted. If `s` is exhausted first, or we find an element that doesn't match, we terminate early. Using non-strictness, we can compose these three separate logical steps--the zipping, the termination when the second stream is exhausted, and the termination if a nonmatching element is found or the first stream is exhausted.
 */
-def startsWith[A](s: Stream[A]): Boolean = 
+def startsWith[A](s: LazyList[A]): Boolean = 
   zipAll(s).takeWhile(!_._2.isEmpty) forAll {
     case (h,h2) => h == h2
   }

--- a/answerkey/laziness/15.answer.md
+++ b/answerkey/laziness/15.answer.md
@@ -1,11 +1,11 @@
 ```scala
 /*
-The last element of `tails` is always the empty `Stream`, so we handle this as a special case, by appending it to the output.
+The last element of `tails` is always the empty `LazyList`, so we handle this as a special case, by appending it to the output.
 */
-def tails: Stream[Stream[A]] =
+def tails: LazyList[LazyList[A]] =
   unfold(this) {
     case Empty => None
     case s => Some((s, s drop 1))
-  } append Stream(empty)
+  } append LazyList(empty)
 
 ```

--- a/answerkey/laziness/15.hint.md
+++ b/answerkey/laziness/15.hint.md
@@ -1,1 +1,1 @@
-Try `unfold` with `this` as the starting state. You may want to handle emitting the empty `Stream` at the end as a special case.
+Try `unfold` with `this` as the starting state. You may want to handle emitting the empty `LazyList` at the end as a special case.

--- a/answerkey/laziness/16.answer.md
+++ b/answerkey/laziness/16.answer.md
@@ -1,11 +1,11 @@
 ```scala
 /*
-The function can't be implemented using `unfold`, since `unfold` generates elements of the `Stream` from left to right. It can be implemented using `foldRight` though.
+The function can't be implemented using `unfold`, since `unfold` generates elements of the `LazyList` from left to right. It can be implemented using `foldRight` though.
 
 The implementation is just a `foldRight` that keeps the accumulated value and the stream of intermediate results, which we `cons` onto during each iteration. When writing folds, it's common to have more state in the fold than is needed to compute the result. Here, we simply extract the accumulated list once finished.
 */
-  def scanRight[B](z: B)(f: (A, => B) => B): Stream[B] =
-    foldRight((z, Stream(z)))((a, p0) => {
+  def scanRight[B](z: B)(f: (A, => B) => B): LazyList[B] =
+    foldRight((z, LazyList(z)))((a, p0) => {
       // p0 is passed by-name and used in by-name args in f and cons. So use lazy val to ensure only one evaluation...
       lazy val p1 = p0
       val b2 = f(a, p1._1)

--- a/answerkey/laziness/16.hint.md
+++ b/answerkey/laziness/16.hint.md
@@ -1,1 +1,1 @@
-The function can't be implemented using `unfold`, since `unfold` generates elements of the `Stream` from left to right. It can be implemented using `foldRight` though.
+The function can't be implemented using `unfold`, since `unfold` generates elements of the `LazyList` from left to right. It can be implemented using `foldRight` though.


### PR DESCRIPTION
The directory `answerkey` uses `Stream` that was deprecated in 2.13. It would be good to replace it with `LazyList`
