### PR TITLE
Update NonblockingSuite.scala

### DIFF
--- a/src/test/scala/fpinscala/exercises/parallelism/NonblockingSuite.scala
+++ b/src/test/scala/fpinscala/exercises/parallelism/NonblockingSuite.scala
@@ -45,7 +45,7 @@ class NonblockingSuite extends PropSuite:
   }
 
   test("Nonblocking.choiceViaFlatMap")(genParInt ** genParInt ** genParBoolean) { case t ** f ** p =>
-    checkChoice(t, f, p)(Par.choiceViaFlatMap[Int](p)(t, f))
+    checkChoice(t, f, p)(Par.choiceViaFlatMap[Int](p)(f, t))
   }
 
   test("Nonblocking.choiceNViaFlatMap")(genParInt ** genListOfParString) { case p ** ps =>


### PR DESCRIPTION
There is a typo in the unit-tests because `choiceViaFlatMap` has the following signature:
`def choiceViaFlatMap[A](p: Par[Boolean])(f: Par[A], t: Par[A]): Par[A]`

https://github.com/fpinscala/fpinscala/blob/second-edition/src/main/scala/fpinscala/exercises/parallelism/Nonblocking.scala#L137