### PR TITLE
Fix chapter 8 syntax

### DIFF
--- a/src/main/scala/fpinscala/answers/parsing/JSON.scala
+++ b/src/main/scala/fpinscala/answers/parsing/JSON.scala
@@ -1,7 +1,5 @@
 package fpinscala.answers.parsing
 
-import language.higherKinds
-
 enum JSON:
   case JNull
   case JNumber(get: Double)

--- a/src/main/scala/fpinscala/answers/parsing/Parsers.scala
+++ b/src/main/scala/fpinscala/answers/parsing/Parsers.scala
@@ -3,7 +3,6 @@ package fpinscala.answers.parsing
 import java.util.regex.*
 import scala.util.matching.Regex
 import fpinscala.answers.testing.*
-import language.higherKinds
 
 trait Parsers[Parser[+_]]:
 

--- a/src/main/scala/fpinscala/exercises/monoids/Monoid.scala
+++ b/src/main/scala/fpinscala/exercises/monoids/Monoid.scala
@@ -1,7 +1,6 @@
 package fpinscala.exercises.monoids
 
 import fpinscala.exercises.parallelism.Nonblocking.*
-import language.higherKinds
 
 trait Monoid[A]:
   def combine(a1: A, a2: A): A

--- a/src/main/scala/fpinscala/exercises/parsing/Parsers.scala
+++ b/src/main/scala/fpinscala/exercises/parsing/Parsers.scala
@@ -1,7 +1,5 @@
 package fpinscala.exercises.parsing
 
-import language.higherKinds
-
 trait Parsers[Parser[+_]] { self => // so inner classes may call methods of trait
 
   case class ParserOps[A](p: Parser[A]) {

--- a/src/main/scala/fpinscala/exercises/parsing/Parsers.scala
+++ b/src/main/scala/fpinscala/exercises/parsing/Parsers.scala
@@ -11,7 +11,7 @@ trait Parsers[Parser[+_]] { self => // so inner classes may call methods of trai
   }
 }
 
-case class Location(input: String, offset: Int = 0) {
+case class Location(input: String, offset: Int = 0):
 
   lazy val line = input.slice(0,offset+1).count(_ == '\n') + 1
   lazy val col = input.slice(0,offset+1).reverse.indexOf('\n')
@@ -29,7 +29,6 @@ case class Location(input: String, offset: Int = 0) {
   def currentLine: String = 
     if (input.length > 1) input.linesIterator.drop(line-1).next()
     else ""
-}
 
 case class ParseError(stack: List[(Location,String)] = List(),
                       otherFailures: List[ParseError] = List()):


### PR DESCRIPTION
After Scala 2.13.1 `higherKinds no longer needs to be imported explicitly` and we can remove it.

Add Scala 3 style for `Location`