### PR TITLE
Surround glob in quotes to avoid tripping up shells

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ gives a list of possible main methods to execute. To run one of them:
 
 To run unit-tests for a file you can do:
 
-    $ scala-cli test . -- fpinscala.exercises.gettingstarted.GettingStartedSuite.*
+    $ scala-cli test . -- 'fpinscala.exercises.gettingstarted.GettingStartedSuite.*'
 
 To run all unit-tests:
 


### PR DESCRIPTION
For example, in fish:

```
~/p/fpinscala (second-edition) > scala-cli test . -- fpinscala.exercises.gettingstarted.GettingStartedSuite.*

fish: No matches for wildcard 'fpinscala.exercises.gettingstarted.GettingStartedSuite.*'. See `help wildcards-globbing`.
scala-cli test . -- fpinscala.exercises.gettingstarted.GettingStartedSuite.*
                    ^
```