### PR TITLE
Is it possible and better to use `cons` instead of `append` in EXERCISE 5.15?

### DIFF
--- a/answerkey/laziness/15.answer.scala
+++ b/answerkey/laziness/15.answer.scala
@@ -2,7 +2,10 @@
 The last element of `tails` is always the empty `Stream`, so we handle this as a special case, by appending it to the output.
 */
 def tails: Stream[Stream[A]] =
-  unfold(this) {
-    case Empty => None
-    case s => Some((s, s drop 1))
-  } append Stream(empty)
+  cons(
+    this,
+    unfold(this) {
+      case Empty => None
+      case Cons(_, t) => Some(t(), t())
+    }
+  )


### PR DESCRIPTION
In EXERCISE 5.15, I assumed that `append` was computationally inefficient compared to `cons`, so I implemented it using `cons`.

However, am I correct in my assumption that `append` is inefficient?
Is it not as inefficient as `append` in `List` due to the lazy processing of `Stream`?
(I'm a little confused, partly because append is implemented using foldRight.)

I would appreciate your advice.