### PR TITLE
first-edition-sbt-update: Bump sbt and Scala versions

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,4 +1,4 @@
-ThisBuild / scalaVersion := "2.13.6"
+ThisBuild / scalaVersion := "2.13.11"
 
 lazy val root = (project in file("."))
   .aggregate(exercises, answers)

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.8.0
+sbt.version=1.9.0


### PR DESCRIPTION
Bump sbt to 1.9.0 and Scala to 2.13.11