### PR TITLE
Chapter 3 - List.zipWith refactor

### DIFF
--- a/src/test/scala/fpinscala/exercises/datastructures/ListSuite.scala
+++ b/src/test/scala/fpinscala/exercises/datastructures/ListSuite.scala
@@ -120,7 +120,7 @@ class ListSuite extends PropSuite:
   test("List.zipWith")(genIntList ** genIntList):
     case list1 ** list2 =>
       val expectedSList = listToScalaList(list1).zip(listToScalaList(list2)).map(_ * _)
-      assertEquals(List.zipWith(list1, list2, _ * _), scalaListToList(expectedSList))
+      assertEquals(List.zipWith(list1, list2, (a, b) => a * b), scalaListToList(expectedSList))
    */
 
   test("List.hasSubsequence")(genIntList ** genSmallNum):


### PR DESCRIPTION
[According to the answers](https://github.com/fpinscala/fpinscala/blob/second-edition/answerkey/datastructures/23.answer.md), `List.zipWith` method signature should be like this: `f: (A,B) => C` and it's better to use tuple as a parameter.

