### PR TITLE
fix: change takeWhile test condition to avoid false positive implementation by forcing coverage of all cases.

### DIFF
--- a/src/test/scala/fpinscala/exercises/laziness/LazyListSuite.scala
+++ b/src/test/scala/fpinscala/exercises/laziness/LazyListSuite.scala
@@ -48,7 +48,7 @@ class LazyListSuite extends PropSuite:
 
   test("LazyList.takeWhile")(genSmallInt ** genLazyList):
     case n ** lazyList =>
-      assertEquals(lazyList.takeWhile(_ != n).toList, lazyList.toList.takeWhile(_ != n))
+      assertEquals(lazyList.takeWhile(_ < n).toList, lazyList.toList.takeWhile(_ < n))
 
   test("LazyList.forAll")(genSmallInt ** genLazyList):
     case n ** lazyList =>


### PR DESCRIPTION
```scala
case LazyList.Cons(h, t) if p(h()) =>
      LazyList.cons(h(), t().takeWhile(p))
    case LazyList.Empty => LazyList.Empty
```

With != n this implementation was passing, and its not covering all possible paths. By changing it to < n, we force it to exhaust all posibilities.