### PR TITLE
update Scala-cli setup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,9 @@
 name := "fpinscala"
 
-ThisBuild / scalaVersion := "3.3.0"
+ThisBuild / scalaVersion := "3.3.3"
 
 ThisBuild / githubWorkflowBuild := Seq(WorkflowStep.Sbt(name = Some("Build project"), commands = List("test:compile")))
 
 ThisBuild / scalacOptions ++= List("-feature", "-deprecation", "-Ykind-projector:underscores", "-source:future")
 
-ThisBuild / libraryDependencies += "org.scalameta" %% "munit" % "0.7.29" % Test
+ThisBuild / libraryDependencies += "org.scalameta" %% "munit" % "1.0.0" % Test

--- a/project.scala
+++ b/project.scala
@@ -5,4 +5,4 @@
 //> using options -source:future
 //> using options -Ykind-projector:underscores
 
-//> using toolkit default
+//> using dep org.scalameta::munit:1.0.0

--- a/project.scala
+++ b/project.scala
@@ -1,8 +1,8 @@
-//> using scala 3.3.0
+//> using scala 3.3.3
 
 //> using options -feature
 //> using options -deprecation
 //> using options -source:future
 //> using options -Ykind-projector:underscores
 
-//> using lib org.scalameta::munit:0.7.29
+//> using toolkit default


### PR DESCRIPTION
- changed Scala to current LTS version 3.3.3
- Scala-cli recommends a `project.scala` file as best practice, so renamed `build.scala`
- The Scala Toolkit contains `munit` by default, so replaced the library dependency with `toolkit`