### PR TITLE
Simplify match cases

### DIFF
--- a/src/main/scala/fpinscala/answers/laziness/LazyList.scala
+++ b/src/main/scala/fpinscala/answers/laziness/LazyList.scala
@@ -104,8 +104,7 @@ enum LazyList[+A]:
 
   def takeViaUnfold(n: Int): LazyList[A] =
     unfold((this, n)):
-      case (Cons(h, t), 1) => Some((h(), (empty, 0)))
-      case (Cons(h, t), n) if n > 1 => Some((h(), (t(), n-1)))
+      case (Cons(h, t), n) if n > 0 => Some((h(), (t(), n-1)))
       case _ => None
 
   def takeWhileViaUnfold(f: A => Boolean): LazyList[A] =


### PR DESCRIPTION
For ```takeViaUnfold```, the logic should be same when the ```n```  equals to and greater than **1**. We are telling ```unfold``` to how many items, ```n```, should be created. So the indicator situation is if ```n``` is greater than **0**. Therefore that should be the case.  

**5** items to  create => ```Some```

**1** item to create => ```Some```

**0** items to create => ```None```