### PR TITLE
Refactor state.Candy.simulateMachine

### DIFF
--- a/src/main/scala/fpinscala/answers/state/State.scala
+++ b/src/main/scala/fpinscala/answers/state/State.scala
@@ -171,9 +171,6 @@ object State:
   def sequence[S, A](actions: List[State[S, A]]): State[S, List[A]] =
     actions.foldRight(unit[S, List[A]](Nil))((f, acc) => f.map2(acc)(_ :: _))
 
-  def traverse[S, A, B](as: List[A])(f: A => State[S, B]): State[S, List[B]] =
-    as.foldRight(unit[S, List[B]](Nil))((a, acc) => f(a).map2(acc)(_ :: _))
-
   def modify[S](f: S => S): State[S, Unit] =
     for
       s <- get // Gets the current state and assigns it to `s`.
@@ -192,7 +189,7 @@ case class Machine(locked: Boolean, candies: Int, coins: Int)
 object Candy:
   def simulateMachine(inputs: List[Input]): State[Machine, (Int, Int)] = 
     for
-      _ <- State.traverse(inputs)(i => State.modify(update(i)))
+      _ <- State.sequence(inputs.map(update).map(State.modify))
       s <- State.get
     yield (s.coins, s.candies)
 


### PR DESCRIPTION
I would like to bring up the following idea, to discard `traverse`,
in favor of `sequence` for the solution for the simulateMachine
problem of Chapter 6 State.Candy.simulateMachine.

```
// Change this
State.traverse(inputs)(i => State.modify(update(i)))

// to this
State.sequence(inputs.map(update).map(State.modify))
```


The reasons being the following.
* Build on existing functionality
* Rely on single purpose functions and compose them to
  achieve more complex functionality

More detailed explanation. `traverse` is not discussed
throughout the chapter (2nd edition), whereas `sequence` is
part of the chapter. It is easier to build upon the previous
exercises than creating new functions.

`traverse` does 2 things: First, takes a `List[A]` and maps
`A => State[S, B]`. Second and combine the `State[S, B]`
values into a single `State[S, List[B]]` value.

While this is not a huge departure from the other exercises, it
makes understanding the solution pipeline a little difficult by
merging these two steps together.

Using `sequence`, requires us to do the mapping step manually
(`A => State[S, B]`) before we can feed them to sequence.
However keeping these steps clearly separate makes the
solution more expressive (hopefully).

One downside that this solution has is that it requires two
passes through the list: One for mapping `List[A] => List[State[S, B]]`
and another to combine these into a `State[S, List[B]]`. 

However, it could be a sensible trade off in favor of simplicity
(hopefully). Which could be solved very elegantly by bringing
in `LazyList` and doing: 
`State.sequence(LazyList(inputs*).map(update).map(State.modify).toList)`
But lets keep it simple for now.